### PR TITLE
Switched to use the useState hook

### DIFF
--- a/.changeset/good-badgers-poke.md
+++ b/.changeset/good-badgers-poke.md
@@ -1,0 +1,5 @@
+---
+"@chart-it/react-d3": minor
+---
+
+Fixes issues with linkStores in production builds

--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -18,7 +18,6 @@ module.exports = {
     setupFiles: ["react-app-polyfill/jsdom"],
     setupFilesAfterEnv: ["<rootDir>/config/jest/setupTests.js"],
     testEnvironment: "jsdom",
-    //testMatch: ["**/*.unit.js", "**/*.unit.jsx"],
     testMatch: ["**/*.unit.js"],
     transformIgnorePatterns: [
         "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$",

--- a/packages/react/src/components/Chart/Chart.jsx
+++ b/packages/react/src/components/Chart/Chart.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import PropTypes from "prop-types";
-import { useDispatch } from "react-redux";
+import { useStore } from "react-redux";
 
 import { VirtualCanvas } from "../VirtualCanvas";
 
@@ -23,28 +23,28 @@ const Chart = ({
     onClick,
     theme = "light",
 }) => {
-    const dispatch = useDispatch();
+    const store = useStore();
 
     // Ensure that the store is updated whenever the dimensions change. This typically
     // triggers scale recalculations which should trigger cascading updates
     useEffect(() => {
-        dispatch(chartActions.setDimensions(width, height, margin));
-    }, [dispatch, width, height, margin]);
+        store.dispatch(chartActions.setDimensions(width, height, margin));
+    }, [store.dispatch, width, height, margin]);
 
     // Ensure that the data used by all plots is updated in the store
     useEffect(() => {
-        dispatch(chartActions.setData(data));
-    }, [dispatch, data]);
+        store.dispatch(chartActions.setData(data));
+    }, [store.dispatch, data]);
 
     useEffect(() => {
-        dispatch(chartActions.setAnimationDuration(animationDuration));
-    }, [dispatch, animationDuration]);
+        store.dispatch(chartActions.setAnimationDuration(animationDuration));
+    }, [store.dispatch, animationDuration]);
 
     useEffect(() => {
         if (theme) {
-            dispatch(chartActions.setTheme(theme));
+            store.dispatch(chartActions.setTheme(theme));
         }
-    }, [dispatch, theme]);
+    }, [store.dispatch, theme]);
 
     // We need to extend the child components to provide the common props. We do this by
     // cloning them and piping the common props down

--- a/packages/react/src/components/EventReceiver/EventReceiver.jsx
+++ b/packages/react/src/components/EventReceiver/EventReceiver.jsx
@@ -4,7 +4,7 @@ import * as d3 from "d3";
 import { throttle } from "lodash";
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import { chartSelectors, eventActions } from "../../store";
 import { MOUSE_MOVE_THROTTLE } from "../../constants";
@@ -14,7 +14,7 @@ import { MOUSE_MOVE_THROTTLE } from "../../constants";
  * @return {ReactElement}  The EventReceiver component
  */
 const EventReceiver = ({ layer }) => {
-    const dispatch = useDispatch();
+    const store = useStore();
     const width = useSelector((s) => chartSelectors.dimensions.width(s));
     const height = useSelector((s) => chartSelectors.dimensions.height(s));
     const margin = useSelector((s) => chartSelectors.dimensions.margin(s));
@@ -27,7 +27,7 @@ const EventReceiver = ({ layer }) => {
 
         const mouseMove = throttle(
             (e) => {
-                dispatch(eventActions.mouseMove(e));
+                store.dispatch(eventActions.mouseMove(e));
             },
             MOUSE_MOVE_THROTTLE,
             { leading: true }
@@ -38,12 +38,12 @@ const EventReceiver = ({ layer }) => {
             .select("rect")
             .attr("width", width - margin.left - margin.right)
             .attr("height", height - margin.top - margin.bottom)
-            .on("mouseout", (e) => { dispatch(eventActions.mouseExit(e)); })
-            .on("mouseover", (e) => { dispatch(eventActions.mouseEnter(e)); })
+            .on("mouseout", (e) => { store.dispatch(eventActions.mouseExit(e)); })
+            .on("mouseover", (e) => { store.dispatch(eventActions.mouseEnter(e)); })
             .on("mousemove", mouseMove);
 
         // Wire up events
-    }, [dispatch, layer, width, height, margin]);
+    }, [store.dispatch, layer, width, height, margin]);
 
     const transform = `translate(${margin.left || 0}, ${margin.top || 0})`;
     return <rect className="chart-it event-receiver" transform={transform} />;

--- a/packages/react/src/components/Plots/Area/Area/AreaBase.jsx
+++ b/packages/react/src/components/Plots/Area/Area/AreaBase.jsx
@@ -1,7 +1,7 @@
 import "./Area.css";
 
 import * as d3 from "d3";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 
 import { useRender } from "../../../../hooks";
@@ -19,7 +19,7 @@ import { useTooltip } from "./useTooltip";
  * @return {ReactElement}  The Line plot component
  */
 const AreaBase = ({ x, y, y2, color, interactive, layer, canvas }) => {
-    const dispatch = useDispatch();
+    const store = useStore();
     const data = useSelector((s) => chartSelectors.data(s));
     const xScale = useSelector((s) => chartSelectors.scales.getScale(s, x));
     const yScale = useSelector((s) => chartSelectors.scales.getScale(s, y));
@@ -85,8 +85,8 @@ const AreaBase = ({ x, y, y2, color, interactive, layer, canvas }) => {
 
     // If possible respond to global mouse events for tooltips etc
     if (interactive) {
-        useDatumFocus(dispatch, layer, x, y, xScale, yScale, sortedData, eventMode, position, strokeColor.toString());
-        useTooltip(dispatch, layer, x, y, xScale, yScale, sortedData, eventMode, position, strokeColor.toString());
+        useDatumFocus(store.dispatch, layer, x, y, xScale, yScale, sortedData, eventMode, position, strokeColor.toString());
+        useTooltip(store.dispatch, layer, x, y, xScale, yScale, sortedData, eventMode, position, strokeColor.toString());
     }
 
     return null;

--- a/packages/react/src/components/Plots/Area/StackedArea/StackedAreaBase.jsx
+++ b/packages/react/src/components/Plots/Area/StackedArea/StackedAreaBase.jsx
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { interpolatePath } from "d3-interpolate-path";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 
 import { useRender } from "../../../../hooks";
@@ -18,7 +18,7 @@ import { useMultiPathCreator } from "./useMultiPathCreator";
  * @return {ReactDOMComponent}  The Line plot component
  */
 const StackedAreaBase = ({ x, ys, colors, interactive, layer, canvas }) => {
-    const dispatch = useDispatch();
+    const store = useStore();
     const data = useSelector((s) => chartSelectors.data(s));
     const xScale = useSelector((s) => chartSelectors.scales.getScale(s, x));
     const yScale = useSelector((s) => chartSelectors.scales.getScale(s, ys[0]));
@@ -107,8 +107,8 @@ const StackedAreaBase = ({ x, ys, colors, interactive, layer, canvas }) => {
 
     // If possible respond to global mouse events for tooltips etc
     if (interactive) {
-        useDatumFocus(dispatch, layer, x, ys, xScale, yScale, sortedData, eventMode, position, colors);
-        useTooltip(dispatch, layer, x, ys, xScale, yScale, sortedData, eventMode, position, colors);
+        useDatumFocus(store.dispatch, layer, x, ys, xScale, yScale, sortedData, eventMode, position, colors);
+        useTooltip(store.dispatch, layer, x, ys, xScale, yScale, sortedData, eventMode, position, colors);
     }
 
     return null;

--- a/packages/react/src/components/Plots/Bar/Bar/BarBase.jsx
+++ b/packages/react/src/components/Plots/Bar/Bar/BarBase.jsx
@@ -43,7 +43,7 @@ const BarBase = ({
     const fillColor = d3.color(color || theme.series.colors[0]);
     fillColor.opacity = theme.series.opacity;
     const strokeColor = "#fff";
-    const setTooltip = useTooltip({ dispatch: store.dispatch, y });
+    const setTooltip = useTooltip(store.dispatch, y);
 
     // This useEffect handles mouseOver/mouseExit through the use of the `focused` value
     useEffect(() => {

--- a/packages/react/src/components/Plots/Bar/Bar/BarBase.jsx
+++ b/packages/react/src/components/Plots/Bar/Bar/BarBase.jsx
@@ -1,7 +1,7 @@
 import * as d3 from "d3";
 
 import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import { useRender } from "../../../../hooks";
 import { chartSelectors, eventActions } from "../../../../store";
@@ -30,7 +30,7 @@ const BarBase = ({
     layer,
 }) => {
     const [focused, setFocused] = useState(null);
-    const dispatch = useDispatch();
+    const store = useStore();
 
     const data = useSelector((s) => chartSelectors.data(s));
     const width = useSelector((s) => chartSelectors.dimensions.width(s));
@@ -43,7 +43,7 @@ const BarBase = ({
     const fillColor = d3.color(color || theme.series.colors[0]);
     fillColor.opacity = theme.series.opacity;
     const strokeColor = "#fff";
-    const setTooltip = useTooltip({ dispatch, y });
+    const setTooltip = useTooltip({ dispatch: store.dispatch, y });
 
     // This useEffect handles mouseOver/mouseExit through the use of the `focused` value
     useEffect(() => {
@@ -51,14 +51,14 @@ const BarBase = ({
 
         const selection = d3.select(focused.element).style("opacity", theme.series.selectedOpacity);
         const dropline = getDropline(selection, yScale, false);
-        dispatch(eventActions.addDropline(dropline));
+        store.dispatch(eventActions.addDropline(dropline));
 
         // Clean up operations on exit
         return () => {
             selection.style("opacity", theme.series.opacity);
-            dispatch(eventActions.removeDropline(dropline));
+            store.dispatch(eventActions.removeDropline(dropline));
         };
-    }, [dispatch, focused, yScale, theme.series.selectedOpacity]);
+    }, [store.dispatch, focused, yScale, theme.series.selectedOpacity]);
 
     useRender(() => {
         if (ensureBandScale(yScale, "Bar") === false) return null;

--- a/packages/react/src/components/Plots/Bar/GroupedBar/GroupedBarBase.jsx
+++ b/packages/react/src/components/Plots/Bar/GroupedBar/GroupedBarBase.jsx
@@ -1,7 +1,7 @@
 import * as d3 from "d3";
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import { useRender } from "../../../../hooks";
 import { chartSelectors, eventActions } from "../../../../store";
@@ -30,7 +30,7 @@ const GroupedBarBase = ({
     renderVirtualCanvas,
 }) => {
     const [focused, setFocused] = useState(null);
-    const dispatch = useDispatch();
+    const store = useStore();
 
     const data = useSelector((s) => chartSelectors.data(s));
     const height = useSelector((s) => chartSelectors.dimensions.height(s));
@@ -41,7 +41,7 @@ const GroupedBarBase = ({
     const animationDuration = useSelector((s) => chartSelectors.animationDuration(s));
 
     const strokeColor = "#fff";
-    const setTooltip = useTooltip({ dispatch, y });
+    const setTooltip = useTooltip({ dispatch: store.dispatch, y });
 
     // This useEffect handles mouseOver/mouseExit through the use of the `focused` value
     useEffect(() => {
@@ -49,14 +49,14 @@ const GroupedBarBase = ({
 
         const selection = d3.select(focused.element).style("opacity", theme.series.selectedOpacity);
         const dropline = getDropline(selection, yScale, true);
-        dispatch(eventActions.addDropline(dropline));
+        store.dispatch(eventActions.addDropline(dropline));
 
         // Clean up operations on exit
         return () => {
             selection.style("opacity", theme.series.opacity);
-            dispatch(eventActions.removeDropline(dropline));
+            store.dispatch(eventActions.removeDropline(dropline));
         };
-    }, [dispatch, focused, yScale, theme.series.opacity, theme.series.selectedOpacity]);
+    }, [store.dispatch, focused, yScale, theme.series.opacity, theme.series.selectedOpacity]);
 
     useRender(() => {
         if (ensureBandScale(yScale, "GroupedBar") === false) return null;

--- a/packages/react/src/components/Plots/Bar/GroupedBar/GroupedBarBase.jsx
+++ b/packages/react/src/components/Plots/Bar/GroupedBar/GroupedBarBase.jsx
@@ -41,7 +41,7 @@ const GroupedBarBase = ({
     const animationDuration = useSelector((s) => chartSelectors.animationDuration(s));
 
     const strokeColor = "#fff";
-    const setTooltip = useTooltip({ dispatch: store.dispatch, y });
+    const setTooltip = useTooltip(store.dispatch, y);
 
     // This useEffect handles mouseOver/mouseExit through the use of the `focused` value
     useEffect(() => {

--- a/packages/react/src/components/Plots/Bar/StackedBar/StackedBarBase.jsx
+++ b/packages/react/src/components/Plots/Bar/StackedBar/StackedBarBase.jsx
@@ -1,7 +1,7 @@
 import * as d3 from "d3";
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import { useRender } from "../../../../hooks";
 import { chartSelectors, eventActions } from "../../../../store";
@@ -31,7 +31,7 @@ const StackedBarBase = ({
     renderVirtualCanvas,
 }) => {
     const [focused, setFocused] = useState(null);
-    const dispatch = useDispatch();
+    const store = useStore();
 
     const data = useSelector((s) => chartSelectors.data(s));
     const height = useSelector((s) => chartSelectors.dimensions.height(s));
@@ -42,7 +42,7 @@ const StackedBarBase = ({
     const animationDuration = useSelector((s) => chartSelectors.animationDuration(s));
 
     const strokeColor = "#fff";
-    const setTooltip = useTooltip({ dispatch, y });
+    const setTooltip = useTooltip(store.dispatch, y);
 
     // This useEffect handles mouseOver/mouseExit through the use of the `focused` value
     useEffect(() => {
@@ -50,14 +50,14 @@ const StackedBarBase = ({
 
         const selection = d3.select(focused.element).style("opacity", theme.series.selectedOpacity);
         const dropline = getDropline(selection, yScale, false);
-        dispatch(eventActions.addDropline(dropline));
+        store.dispatch(eventActions.addDropline(dropline));
 
         // Clean up operations on exit
         return () => {
             selection.style("opacity", theme.series.opacity);
-            dispatch(eventActions.removeDropline(dropline));
+            store.dispatch(eventActions.removeDropline(dropline));
         };
-    }, [dispatch, focused, yScale, theme.series.opacity, theme.series.selectedOpacity]);
+    }, [store.dispatch, focused, yScale, theme.series.opacity, theme.series.selectedOpacity]);
 
     useRender(() => {
         if (ensureBandScale(yScale, "StackedBar") === false) return null;

--- a/packages/react/src/components/Plots/Bar/useTooltip.js
+++ b/packages/react/src/components/Plots/Bar/useTooltip.js
@@ -4,11 +4,11 @@ import { eventActions } from "../../../store";
 
 /**
  * Handles the user interacting with a DataPoint on the Column chart and the need to display a tooltip
- * @param  {Function} options.dispatch     The redux store dispatch function
- * @param  {String} options.y              The key for the y value
- * @return {Function}                      A function to set the tooltip datum
+ * @param  {Function} dispatch     The redux store dispatch function
+ * @param  {String} y              The key for the y value
+ * @return {Function}              A function to set the tooltip datum
  */
-const useTooltip = ({ dispatch, y }) => {
+const useTooltip = (dispatch, y) => {
     const [datum, setDatum] = useState(null);
     const [colors, setColors] = useState(null);
     const [xs, setXs] = useState(null);

--- a/packages/react/src/components/Plots/Column/Column/ColumnBase.jsx
+++ b/packages/react/src/components/Plots/Column/Column/ColumnBase.jsx
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import { useRender } from "../../../../hooks";
 import { chartSelectors, eventActions } from "../../../../store";
@@ -29,7 +29,7 @@ const ColumnBase = ({
     layer,
 }) => {
     const [focused, setFocused] = useState(null);
-    const dispatch = useDispatch();
+    const store = useStore();
 
     const data = useSelector((s) => chartSelectors.data(s));
     const width = useSelector((s) => chartSelectors.dimensions.width(s));
@@ -43,21 +43,21 @@ const ColumnBase = ({
     const fillColor = d3.color(color || theme.series.colors[0]);
     fillColor.opacity = theme.series.opacity;
 
-    const setTooltip = useTooltip({ dispatch, x });
+    const setTooltip = useTooltip(store.dispatch, x);
 
     useEffect(() => {
         if (!focused) return;
 
         const selection = d3.select(focused.element).style("opacity", theme.series.selectedOpacity);
         const dropline = getDropline(selection, xScale, true);
-        dispatch(eventActions.addDropline(dropline));
+        store.dispatch(eventActions.addDropline(dropline));
 
         // Clean up operations on exit
         return () => {
             selection.style("opacity", theme.series.opacity);
-            dispatch(eventActions.removeDropline(dropline));
+            store.dispatch(eventActions.removeDropline(dropline));
         };
-    }, [dispatch, focused, xScale, theme.series.selectedOpacity]);
+    }, [store.dispatch, focused, xScale, theme.series.selectedOpacity]);
 
     useRender(() => {
         if (ensureBandScale(xScale, "Column") === false) return null;

--- a/packages/react/src/components/Plots/Column/GroupedColumn/GroupedColumnBase.jsx
+++ b/packages/react/src/components/Plots/Column/GroupedColumn/GroupedColumnBase.jsx
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import { useRender } from "../../../../hooks";
 import { chartSelectors, eventActions } from "../../../../store";
@@ -29,7 +29,7 @@ const GroupedColumnBase = ({
     renderVirtualCanvas,
 }) => {
     const [focused, setFocused] = useState(null);
-    const dispatch = useDispatch();
+    const store = useStore();
 
     const data = useSelector((s) => chartSelectors.data(s));
     const height = useSelector((s) => chartSelectors.dimensions.height(s));
@@ -40,7 +40,7 @@ const GroupedColumnBase = ({
     const animationDuration = useSelector((s) => chartSelectors.animationDuration(s));
 
     const strokeColor = "#fff";
-    const setTooltip = useTooltip({ dispatch, x });
+    const setTooltip = useTooltip(store.dispatch, x);
 
     // This useEffect handles mouseOver/mouseExit through the use of the `focused` value
     useEffect(() => {
@@ -48,14 +48,14 @@ const GroupedColumnBase = ({
 
         const selection = d3.select(focused.element).style("opacity", theme.series.selectedOpacity);
         const dropline = getDropline(selection, xScale, true);
-        dispatch(eventActions.addDropline(dropline));
+        store.dispatch(eventActions.addDropline(dropline));
 
         // Clean up operations on exit
         return () => {
             selection.style("opacity", theme.series.opacity);
-            dispatch(eventActions.removeDropline(dropline));
+            store.dispatch(eventActions.removeDropline(dropline));
         };
-    }, [dispatch, focused, xScale, theme.series.opacity, theme.series.selectedOpacity]);
+    }, [store.dispatch, focused, xScale, theme.series.opacity, theme.series.selectedOpacity]);
 
     useRender(() => {
         if (ensureBandScale(xScale, "GroupedColumn") === false) return null;

--- a/packages/react/src/components/Plots/Column/StackedColumn/StackedColumnBase.jsx
+++ b/packages/react/src/components/Plots/Column/StackedColumn/StackedColumnBase.jsx
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import { useRender } from "../../../../hooks";
 import { chartSelectors, eventActions } from "../../../../store";
@@ -30,7 +30,7 @@ const StackedColumnBase = ({
     renderVirtualCanvas,
 }) => {
     const [focused, setFocused] = useState(null);
-    const dispatch = useDispatch();
+    const store = useStore();
 
     const data = useSelector((s) => chartSelectors.data(s));
     const height = useSelector((s) => chartSelectors.dimensions.height(s));
@@ -41,21 +41,21 @@ const StackedColumnBase = ({
     const animationDuration = useSelector((s) => chartSelectors.animationDuration(s));
 
     const strokeColor = "#fff";
-    const setTooltip = useTooltip({ dispatch, x });
+    const setTooltip = useTooltip(store.dispatch, x);
 
     useEffect(() => {
         if (!focused) return;
 
         const selection = d3.select(focused.element).style("opacity", theme.series.selectedOpacity);
         const dropline = getDropline(selection, xScale);
-        dispatch(eventActions.addDropline(dropline));
+        store.dispatch(eventActions.addDropline(dropline));
 
         // Clean up operations on exit
         return () => {
             selection.style("opacity", theme.series.opacity);
-            dispatch(eventActions.removeDropline(dropline));
+            store.dispatch(eventActions.removeDropline(dropline));
         };
-    }, [dispatch, focused, xScale, theme.series.opacity, theme.series.selectedOpacity]);
+    }, [store.dispatch, focused, xScale, theme.series.opacity, theme.series.selectedOpacity]);
 
     useRender(() => {
         if (ensureBandScale(xScale, "StackedColumnBase") === false) return null;

--- a/packages/react/src/components/Plots/Column/useTooltip.js
+++ b/packages/react/src/components/Plots/Column/useTooltip.js
@@ -4,11 +4,11 @@ import { eventActions } from "../../../store";
 
 /**
  * Handles the user interacting with a DataPoint on the Column chart and the need to display a tooltip
- * @param  {Function} options.dispatch     The redux store dispatch function
- * @param  {String} options.x              The key for the x value
- * @return {Function}                      A function to set the tooltip datum
+ * @param  {Function} dispatch     The redux store dispatch function
+ * @param  {String} x              The key for the x value
+ * @return {Function}              A function to set the tooltip datum
  */
-const useTooltip = ({ dispatch, x }) => {
+const useTooltip = (dispatch, x) => {
     const [datum, setDatum] = useState(null);
     const [colors, setColors] = useState(null);
     const [ys, setYs] = useState(null);

--- a/packages/react/src/components/Plots/Line/Line/CanvasLine/CanvasLine.jsx
+++ b/packages/react/src/components/Plots/Line/Line/CanvasLine/CanvasLine.jsx
@@ -1,7 +1,7 @@
 import * as d3 from "d3";
 import PropTypes from "prop-types";
 import React, { useRef } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import { useRender } from "../../../../../hooks";
 import { chartSelectors, eventSelectors } from "../../../../../store";
@@ -16,7 +16,7 @@ import { useTooltip } from "../useTooltip";
  * @return {ReactDOMComponent}  The Line plot component
  */
 const CanvasLine = ({ x, y, color, layer, canvas }) => {
-    const dispatch = useDispatch();
+    const store = useStore();
     const gRef = useRef(null);
     const data = useSelector((s) => chartSelectors.data(s));
     const xScale = useSelector((s) => chartSelectors.scales.getScale(s, x));
@@ -64,8 +64,8 @@ const CanvasLine = ({ x, y, color, layer, canvas }) => {
     }, [x, y, sortedData, xScale, yScale, layer, canvas, width, height]);
 
     // If possible respond to global mouse events for tooltips etc
-    useDatumFocus(dispatch, gRef, x, y, xScale, yScale, sortedData, eventMode, position, seriesColor);
-    useTooltip(dispatch, gRef, x, y, xScale, yScale, sortedData, eventMode, position, seriesColor);
+    useDatumFocus(store.dispatch, gRef, x, y, xScale, yScale, sortedData, eventMode, position, seriesColor);
+    useTooltip(store.dispatch, gRef, x, y, xScale, yScale, sortedData, eventMode, position, seriesColor);
 
     return <g ref={gRef} />;
 };

--- a/packages/react/src/components/Plots/Line/Line/SVGLine/SVGLine.jsx
+++ b/packages/react/src/components/Plots/Line/Line/SVGLine/SVGLine.jsx
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import { useRender } from "../../../../../hooks";
 import { chartSelectors, eventSelectors } from "../../../../../store";
@@ -16,7 +16,7 @@ import { usePathCreator } from "./usePathCreator";
  * @return {ReactDOMComponent}  The Line plot component
  */
 const SVGLine = ({ x, y, color, interactive, layer, canvas }) => {
-    const dispatch = useDispatch();
+    const store = useStore();
     const data = useSelector((s) => chartSelectors.data(s));
     const xScale = useSelector((s) => chartSelectors.scales.getScale(s, x));
     const yScale = useSelector((s) => chartSelectors.scales.getScale(s, y));
@@ -58,8 +58,8 @@ const SVGLine = ({ x, y, color, interactive, layer, canvas }) => {
 
     // If possible respond to global mouse events for tooltips etc
     if (interactive) {
-        useDatumFocus(dispatch, layer, x, y, xScale, yScale, sortedData, eventMode, position, seriesColor);
-        useTooltip(dispatch, layer, x, y, xScale, yScale, sortedData, eventMode, position, seriesColor);
+        useDatumFocus(store.dispatch, layer, x, y, xScale, yScale, sortedData, eventMode, position, seriesColor);
+        useTooltip(store.dispatch, layer, x, y, xScale, yScale, sortedData, eventMode, position, seriesColor);
     }
 
     return null;

--- a/packages/react/src/components/Plots/Scatter/Scatter/ScatterBase.jsx
+++ b/packages/react/src/components/Plots/Scatter/Scatter/ScatterBase.jsx
@@ -1,7 +1,7 @@
 import * as d3 from "d3";
 import PropTypes from "prop-types";
 import { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import { useFocused } from "./useFocused";
 import { useTooltip } from "./useTooltip";
@@ -29,7 +29,7 @@ const ScatterBase = ({
     onClick,
     layer,
 }) => {
-    const dispatch = useDispatch();
+    const store = useStore();
     const data = useSelector((s) => chartSelectors.data(s));
     const width = useSelector((s) => chartSelectors.dimensions.width(s));
     const height = useSelector((s) => chartSelectors.dimensions.height(s));
@@ -46,8 +46,8 @@ const ScatterBase = ({
 
     const bandwidth = xScale.bandwidth ? xScale.bandwidth() / 2 : 0;
 
-    const setFocused = useFocused({ dispatch, xScale, yScale });
-    const setTooltip = useTooltip({ dispatch, x, y });
+    const setFocused = useFocused({ dispatch: store.dispatch, xScale, yScale });
+    const setTooltip = useTooltip({ dispatch: store.dispatch, x, y });
 
     // This is the main render function
     useEffect(() => {

--- a/packages/react/src/components/Scale/Scale.jsx
+++ b/packages/react/src/components/Scale/Scale.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import { chartActions, chartSelectors } from "../../store";
 import { calculateScale } from "./calculateScale";
@@ -10,7 +10,7 @@ import { calculateScale } from "./calculateScale";
  * @return {ReactDOMComponent}   A scale component
  */
 const Scale = ({ fields, range, scaleType, aggregate, domain, fromAxis }) => {
-    const dispatch = useDispatch();
+    const store = useStore();
     const data = useSelector((s) => chartSelectors.data(s));
 
     useEffect(() => {
@@ -19,8 +19,8 @@ const Scale = ({ fields, range, scaleType, aggregate, domain, fromAxis }) => {
 
         // Use the fixed range if one was provided
         const scale = calculateScale(data, fields, range, domain, aggregate, scaleType);
-        dispatch(chartActions.setScales(fields, scale, fromAxis));
-    }, [fields, data, range, scaleType, aggregate, dispatch]);
+        store.dispatch(chartActions.setScales(fields, scale, fromAxis));
+    }, [fields, data, range, scaleType, aggregate, store.dispatch]);
 
     return <React.Fragment />;
 };
@@ -56,7 +56,7 @@ Scale.propTypes = {
      * @type {Array}
      */
     domain: PropTypes.arrayOf(
-        PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Date), PropTypes.string, PropTypes.bool]),
+        PropTypes.oneOfType([PropTypes.number, PropTypes.instanceOf(Date), PropTypes.string, PropTypes.bool])
     ),
 };
 

--- a/packages/react/src/components/VirtualCanvas/VirtualCanvas.jsx
+++ b/packages/react/src/components/VirtualCanvas/VirtualCanvas.jsx
@@ -3,7 +3,7 @@ import "./VirtualCanvas.css";
 import { debounce } from "lodash";
 import PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useStore, useSelector } from "react-redux";
 
 import {
     addEventHandlers,
@@ -33,7 +33,7 @@ export const VirtualCanvas = (props) => {
     const canvas = useRef(null);
     const width = useSelector((s) => chartSelectors.dimensions.width(s));
     const height = useSelector((s) => chartSelectors.dimensions.height(s));
-    const dispatch = useDispatch();
+    const store = useStore();
 
     // Render all the virtual nodes - this is debounced to ensure that we only trigger it once
     // after all of the child layers finished their render as we don't want layers to overwrite each other
@@ -66,13 +66,13 @@ export const VirtualCanvas = (props) => {
             return;
         }
 
-        const { clickHandler, moveHandler } = addEventHandlers(canvasElement, colorToData, dispatch);
+        const { clickHandler, moveHandler } = addEventHandlers(canvasElement, colorToData, store.dispatch);
 
         // Ensure we clean up the handlers otherwise they'll double fire
         return () => {
             removeEventHandlers(canvasElement, clickHandler, moveHandler);
         };
-    }, [canvas, colorToData, onClick, onMouseOut, onMouseOver, dispatch]);
+    }, [canvas, colorToData, onClick, onMouseOut, onMouseOver, store.dispatch]);
 
     // Many layers don't require the virtual canvas. If
     // they are all of these types then disable the canvas

--- a/packages/react/src/stories/Dashboards/Dashboards.stories.jsx
+++ b/packages/react/src/stories/Dashboards/Dashboards.stories.jsx
@@ -105,62 +105,146 @@ const DashboardTemplate = (args) => {
 
     return (
         <div>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore1}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore1}
+            >
                 <Line x="Month" y="Unit Sales" />
                 <YAxis fields={["Unit Sales"]} />
                 <XAxis fields={["Month"]} />
             </XYChart>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore2}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore2}
+            >
                 <Area x="Month" y="Sales Value" />
                 <YAxis fields={["Sales Value"]} />
                 <XAxis fields={["Month"]} />
             </XYChart>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore3}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore3}
+            >
                 <Line x="Month" y="Cost of Sales" />
                 <YAxis fields={["Cost of Sales"]} />
                 <XAxis fields={["Month"]} />
             </XYChart>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore4}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore4}
+            >
                 <Area x="Month" y="Price" />
                 <YAxis fields={["Price"]} />
                 <XAxis fields={["Month"]} />
             </XYChart>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore5}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore5}
+            >
                 <Line x="Month" y="Gross Profit" />
                 <YAxis fields={["Gross Profit"]} />
                 <XAxis fields={["Month"]} />
             </XYChart>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore6}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore6}
+            >
                 <Area x="Month" y="Indirect Costs" />
                 <YAxis fields={["Indirect Costs"]} />
                 <XAxis fields={["Month"]} />
             </XYChart>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore7}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore7}
+            >
                 <Area x="Month" y="Operating Profit" />
                 <YAxis fields={["Operating Profit"]} />
                 <XAxis fields={["Month"]} />
             </XYChart>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore8}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore8}
+            >
                 <Line x="Month" y="Unit Sales Monthly Change" />
                 <YAxis fields={["Unit Sales Monthly Change"]} />
                 <XAxis fields={["Month"]} />
             </XYChart>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore9}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore9}
+            >
                 <Area x="Month" y="Sales Value Monthly Change" />
                 <YAxis fields={["Sales Value Monthly Change"]} />
                 <XAxis fields={["Month"]} />
             </XYChart>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore10}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore10}
+            >
                 <Line x="Month" y="Distribution Monthly Change" />
                 <YAxis fields={["Distribution Monthly Change"]} />
                 <XAxis fields={["Month"]} />
             </XYChart>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore11}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore11}
+            >
                 <Area x="Month" y="Price Monthly Change" />
                 <YAxis fields={["Price Monthly Change"]} />
                 <XAxis fields={["Month"]} />
             </XYChart>
-            <XYChart data={data} margin={args.margin} width={width} height={height} onStoreCreated={setStore12}>
+            <XYChart
+                data={data}
+                useCanvas={args.useCanvas}
+                margin={args.margin}
+                width={width}
+                height={height}
+                onStoreCreated={setStore12}
+            >
                 <Line x="Month" y="Gross Profit Monthly Change" />
                 <YAxis fields={["Gross Profit Monthly Change"]} />
                 <XAxis fields={["Month"]} />


### PR DESCRIPTION
Calling `useDispatch()` returns the dispatch function immediately, which when using `linkStores()` on the dashboard, this was causing the dispatch to reference the original Redux one, rather than the wrapped dispatch.

Therefore we use `getStore()` instead so we lazily get the dispatch function.

Signed-off-by: "Ian Wright" <"ipwright83+dev@gmail.com">