### PR TITLE
Fix flaky Lines multi-series test

### DIFF
--- a/packages/react/src/lib/components/Plots/Line/Lines.unit.tsx
+++ b/packages/react/src/lib/components/Plots/Line/Lines.unit.tsx
@@ -33,7 +33,7 @@ describe("Lines", () => {
 
                 // Wait for the second render of the line, as
                 // first render we put in a placeholder to animate
-                await wait(10);
+                await wait();
 
                 expect(asFragment()).toMatchSnapshot();
             });
@@ -53,7 +53,7 @@ describe("Lines", () => {
 
                 // Wait for the second render of the line, as
                 // first render we put in a placeholder to animate
-                await wait(10);
+                await wait();
 
                 await wait(VIRTUAL_CANVAS_DEBOUNCE * 2);
 


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure seen on #224 (`Lines › Multiple Series › using SVG › should render correctly`), e.g. https://github.com/IPWright83/chart-io/actions/runs/30388741598/job/90374576266.

- `Lines.unit.tsx` waited a fixed `10ms` for the line's D3 transition (flat placeholder → real interpolated path) to settle before calling `toMatchSnapshot()`.
- The transition is scheduled via `d3.timer`, not a synchronous callback, so under CI load 10ms isn't always enough - the snapshot occasionally captures the placeholder frame (`d="M0,100L100,100"`, no stroke) instead of the settled one.
- I reproduced the identical failure (byte-for-byte same diff) on an unrelated commit from 10 days earlier, confirming this is a pre-existing race rather than something introduced by recent changes.
- Switches both `wait(10)` calls in this file to the default `wait()` (200ms), matching how other animated-transition tests in the codebase wait for settling (their comments say the same thing: "wait for the transition to settle").

## Test plan

- [x] `pnpm --filter @chart-io/react test` - all passing
- [x] `pnpm --filter @chart-io/react lint` / `types` - clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01B9rwND39Z1QdQ5So5zgxLC)_