### PR TITLE
Enable npm trusted publishing (OIDC) in the release workflow

### DIFF
--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -39,6 +39,9 @@ jobs:
     needs: [unit]
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       published: ${{ steps.published.outputs.published }}
     steps:
@@ -48,6 +51,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
+      - name: Update npm for trusted publishing (OIDC)
+        run: npm install -g npm@^11.5.1
       - uses: pnpm/action-setup@v2
         with:
           run_install: false
@@ -74,7 +79,6 @@ jobs:
           version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Update output
         id: published
         if: steps.release.outputs.published == 'true'


### PR DESCRIPTION
## Summary
- Now that trusted publishers are configured on npm for `@chart-io/core` and `@chart-io/react`, switch the `changesets_version` job in `push-to-master.yml` over to OIDC-based publishing instead of the (currently broken) `NPM_TOKEN` secret.
- Adds `permissions: id-token: write` (plus explicit `contents: read`) to the job so it can mint a GitHub Actions OIDC token for npm to exchange.
- Bumps the global `npm` CLI to `>=11.5.1` right after `actions/setup-node`, since npm trusted publishing requires that minimum version and the Node 20 setup action bundles an older one.
- Drops the `NPM_TOKEN` env var from the `changesets/action` step — leaving it in place would make the CLI write a classic auth token into `.npmrc` and skip the OIDC flow entirely, defeating the purpose (and reproducing the same `404` publish failure we just diagnosed on the old token).

## Context
This follows on from diagnosing why Storybook/npm publishing had stalled: the "Version Packages" PR had gone unmerged for months, and separately the `NPM_TOKEN` secret had gone stale. Rather than rotate that secret again, the repo owner set up npm's new [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC) support so no long-lived npm token is needed at all.

**Action needed on npmjs.com side (outside this repo):** the trusted publisher config for both `@chart-io/core` and `@chart-io/react` must reference workflow filename `push-to-master.yml` (no path) for this to authenticate correctly.

## Test plan
- [ ] Merge and confirm the next `push-to-master.yml` run's `changesets_version` job publishes successfully via OIDC (no `E404`/auth errors)
- [ ] Confirm `deploy_storybook` and `update_chromatic_baseline` run afterward (gated on `published == 'true'`)
- [ ] Once confirmed working, remove the now-unused `NPM_TOKEN` secret from repo settings

---
_Generated by [Claude Code](https://claude.ai/code/session_01WB62VYThuexdsLmZKzpGfx)_