### PR TITLE
Fix missing RadialArea/RadialAreas package exports

### DIFF
--- a/.changeset/radial-area-exports.md
+++ b/.changeset/radial-area-exports.md
@@ -1,0 +1,5 @@
+---
+"@chart-io/react": patch
+---
+
+Fixed `<RadialArea>` and `<RadialAreas>` not being exported from the package - they were built and documented in Storybook, but missing from the barrel exports, so `import { RadialArea } from "@chart-io/react"` resolved to `undefined`.

--- a/packages/react/src/lib/components/Plots/RadialArea/index.ts
+++ b/packages/react/src/lib/components/Plots/RadialArea/index.ts
@@ -1,0 +1,2 @@
+export * from "./RadialArea";
+export * from "./RadialAreas";

--- a/packages/react/src/lib/components/Plots/index.ts
+++ b/packages/react/src/lib/components/Plots/index.ts
@@ -5,3 +5,4 @@ export * from "./Line";
 export * from "./Area";
 export * from "./Pie";
 export * from "./Radar";
+export * from "./RadialArea";


### PR DESCRIPTION
## Summary

Found this while scoping the upcoming Treemap chart and checking how existing plot folders register themselves in the public package barrel.

- `<RadialArea>`/`<RadialAreas>` were fully built, tested and documented in PR #227, but `packages/react/src/lib/components/Plots/RadialArea/index.ts` was never added, and `Plots/index.ts` never re-exported it - so `import { RadialArea } from "@chart-io/react"` resolved to `undefined`. Every other plot folder (`Bar`, `Radar`, `Pie`, ...) has this barrel file; `RadialArea` was just missing it.
- Verified before the fix: building the package and requiring it showed `typeof pkg.RadialArea === "undefined"`. After adding the barrel export, it's `"function"`.

## Test plan

- [x] `pnpm --filter @chart-io/react types` - clean
- [x] `pnpm --filter @chart-io/react lint` - clean
- [x] `pnpm --filter @chart-io/react test` - 69/69 suites pass (291 tests)
- [x] `pnpm --filter @chart-io/react build`, then verified `RadialArea`/`RadialAreas` are present as functions on the built package's exports (previously `undefined`)
- [x] Added a changeset (`@chart-io/react` patch)


---
_Generated by [Claude Code](https://claude.ai/code/session_01B9rwND39Z1QdQ5So5zgxLC)_