### PR TITLE
Fix stale canvas position breaking Canvas tooltip hit-testing

### DIFF
--- a/.changeset/tooltip-canvas-scroll.md
+++ b/.changeset/tooltip-canvas-scroll.md
@@ -1,0 +1,6 @@
+---
+"@chart-io/core": patch
+"@chart-io/react": patch
+---
+
+Fixed Canvas-rendered charts (e.g. `<Pie useCanvas>`, `<Donut useCanvas>`, `<Column useCanvas>`) not showing tooltips once the page had been scrolled after the chart mounted. The virtual canvas's hit-testing cached the canvas's bounding rect once on mount and never recomputed it, so scrolling (or any reflow that moved the chart) made every subsequent hover/click sample the wrong pixel and silently find no datum.

--- a/packages/core/src/canvas/virtual/addEventHandlers.ts
+++ b/packages/core/src/canvas/virtual/addEventHandlers.ts
@@ -92,8 +92,6 @@ export const addEventHandlers = (
     let lastDatum = undefined;
     let lastNode = undefined;
 
-    // This is a fairly slow operation so let's do it just the once
-    const rect = canvas.getBoundingClientRect();
     const eventContext = canvas.getContext("2d", { willReadFrequently: true });
 
     /**
@@ -104,9 +102,15 @@ export const addEventHandlers = (
     const getDatum = (e: MouseEvent): IColorToData | undefined => {
         const colorToData: IColorToDataMap = getColorMap() ?? {};
 
+        // getBoundingClientRect() is recomputed on every event, rather than cached once, since
+        // the canvas's position can change after the event handlers are wired up (e.g. the page
+        // being scrolled, or the chart's container resizing/reflowing). It's viewport-relative,
+        // so it's offset by the current scroll position to line up with pageX/pageY, which are
+        // document-relative.
+        const rect = canvas.getBoundingClientRect();
         const coords = {
-            x: e.pageX - rect.left,
-            y: e.pageY - rect.top,
+            x: e.pageX - rect.left - window.scrollX,
+            y: e.pageY - rect.top - window.scrollY,
         };
 
         const colorData = eventContext.getImageData(coords.x, coords.y, 1, 1).data;


### PR DESCRIPTION
## Summary

- Fixes Canvas-rendered charts (Pie/Donut included) not showing tooltips: `addEventHandlers()` cached `canvas.getBoundingClientRect()` once when the virtual canvas's event listeners were wired up on mount, then reused that stale rect for every subsequent click/mousemove.
- Once the page scrolled (or the chart's container otherwise moved/resized after mount), the cached rect no longer matched the canvas's real position, so the color-based hit-test in `getDatum()` sampled the wrong pixel of the hidden hit-test canvas and never found a matching datum - the tooltip silently never appeared, even though the mouse was directly over a data point.
- `packages/core/src/canvas/virtual/addEventHandlers.ts` now recomputes `getBoundingClientRect()` on every event, and offsets it by the current `window.scrollX`/`scrollY` so it correctly lines up with the document-relative `pageX`/`pageY` coordinates already used for hit-testing.

## Root cause detail

Reproduced with a real browser (Playwright/Chromium) against the built Storybook, not just the jsdom unit tests (which run with zero scroll/layout, so this bug is invisible to them):

- `RadialCharts/Pie` → `Using Canvas` story: hovering a slice works fine right after page load, but once the page is scrolled down and the chart's viewport position shifts, hovering the same slice produces an **empty** `.g-tooltip-overlay` - no tooltip at all.
- Same reproduction against `XYCharts/Column` → `Using Canvas` confirms this isn't Pie-specific - it's a bug in the shared virtual-canvas hit-testing code used by every Canvas-rendered plot type. Pie/Donut charts are commonly placed lower on a dashboard page, making this much more likely to be hit in practice than for charts near the top of the page.
- After the fix, both scenarios correctly show the tooltip again post-scroll.

## Test plan

- [x] `packages/core` unit tests (`pnpm --filter @chart-io/core test`) - 170 passed
- [x] `packages/react` unit tests (`pnpm --filter @chart-io/react test`) - 307 passed
- [x] Manually verified via a Playwright script against a built Storybook: Pie (Canvas) and Column (Canvas) tooltips both work correctly before and after scrolling the page
- [x] `eslint` on the changed file

---
_Generated by [Claude Code](https://claude.ai/code/session_011T3YgNye1hXWrsf2E8kCpg)_