### PR TITLE
Add data-mutation controls to Basic/Canvas chart stories

### DIFF
--- a/packages/react/src/lib/components/Plots/Area/Area.stories.tsx
+++ b/packages/react/src/lib/components/Plots/Area/Area.stories.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from "react";
 
 import { waves } from "../../../../data/waves";
 import { argTypes } from "../../../../storybook/argTypes";
+import { jitterFields, withDataControls } from "../../../../storybook/dataControls";
 import { createEventReceiverTest } from "../../../testUtils";
 import { XAxis, YAxis } from "../../Axis";
 import { XYChart } from "../../XYChart";
@@ -46,7 +47,7 @@ export default {
 
 const AreaTemplate = (args) => (
   <XYChart
-    data={waves}
+    data={args.data ?? waves}
     plotMargin={{
       left: args.leftMargin,
       right: args.rightMargin,
@@ -64,6 +65,32 @@ const AreaTemplate = (args) => (
     <XAxis fields={[args.x]} />
   </XYChart>
 );
+
+// Wave field names that carry values to animate; "x" stays untouched so points remain ordered.
+const waveFields = ["sin", "cos", "tan", "sinh", "cosh"];
+
+function nextWavePoint(current: typeof waves) {
+  const last = current[current.length - 1] ?? waves[0];
+  const x = last.x + 10;
+  const rad = x * (Math.PI / 180);
+  return {
+    x,
+    sin: Math.sin(rad),
+    cos: Math.cos(rad),
+    tan: Math.tan(rad),
+    sinh: Math.sinh(rad),
+    cosh: Math.cosh(rad),
+  };
+}
+
+const waveDataControls = {
+  initialData: waves,
+  randomize: (row: (typeof waves)[number]) => jitterFields(row, waveFields, 0.3),
+  createPoint: nextWavePoint,
+  minLength: 5,
+};
+
+const AreaTemplateWithControls = withDataControls(AreaTemplate, waveDataControls);
 
 const AreasTemplate = (args) => (
   <XYChart
@@ -120,7 +147,7 @@ const StackedAreasTemplate = (args) => {
 
 export const Basic = {
   name: "Basic Plot",
-  render: AreaTemplate,
+  render: AreaTemplateWithControls,
   args: {
     useCanvas: false,
     width: 800,
@@ -167,7 +194,7 @@ export const Stream = {
 
 export const Canvas = {
   name: "Using Canvas",
-  render: AreaTemplate,
+  render: AreaTemplateWithControls,
   args: {
     ...Basic.args,
     useCanvas: true,

--- a/packages/react/src/lib/components/Plots/Bar/Bar.stories.tsx
+++ b/packages/react/src/lib/components/Plots/Bar/Bar.stories.tsx
@@ -6,6 +6,7 @@ import React from "react";
 
 import { sales_records_dataset } from "../../../../data/sales_records_dataset";
 import { argTypes } from "../../../../storybook/argTypes";
+import { jitterFields, withDataControls } from "../../../../storybook/dataControls";
 import { createCanvasTest, createSVGTest } from "../../../testUtils";
 import { XAxis, YAxis } from "../../Axis";
 import { XYChart } from "../../XYChart";
@@ -50,9 +51,31 @@ export default {
 
 const data = uniqBy(sales_records_dataset, (d) => d["Item Type"]);
 
+// Numeric fields to animate; "Item Type" and the other descriptive fields stay untouched.
+const salesFields = ["Units Sold", "Unit Price", "Unit Cost", "Total Revenue", "Total Cost", "Total Profit"];
+
+function nextSalesRow(current: typeof data) {
+  const usedTypes = new Set(current.map((d) => d["Item Type"]));
+  const candidate = sales_records_dataset.find((d) => !usedTypes.has(d["Item Type"]));
+  if (candidate) {
+    return candidate;
+  }
+  // Every Item Type from the source dataset is already represented - clone a random row under a
+  // synthetic label instead, so the chart still gains a visibly new category
+  const base = current[Math.floor(Math.random() * current.length)];
+  return jitterFields({ ...base, "Item Type": `${base["Item Type"]} (New)` }, salesFields, 0.3);
+}
+
+const salesDataControls = {
+  initialData: data,
+  randomize: (row: (typeof data)[number]) => jitterFields(row, salesFields, 0.3),
+  createPoint: nextSalesRow,
+  minLength: 2,
+};
+
 const BarTemplate = (args) => (
   <XYChart
-    data={data}
+    data={args.data ?? data}
     plotMargin={{
       left: args.leftMargin,
       right: args.rightMargin,
@@ -74,6 +97,8 @@ const BarTemplate = (args) => (
     {args.x2 && <Bar x={args.x2} y={args.y} color={args.color2} />}
   </XYChart>
 );
+
+const BarTemplateWithControls = withDataControls(BarTemplate, salesDataControls);
 
 const BarsTemplate = (args) => (
   <XYChart
@@ -106,7 +131,7 @@ const BarsTemplate = (args) => (
 
 export const Basic = {
   name: "Basic Plot",
-  render: BarTemplate,
+  render: BarTemplateWithControls,
   args: {
     useCanvas: false,
     width: 800,
@@ -136,7 +161,7 @@ export const Color = {
 
 export const Canvas = {
   name: "Using Canvas",
-  render: BarTemplate,
+  render: BarTemplateWithControls,
   args: {
     ...Basic.args,
     useCanvas: true,

--- a/packages/react/src/lib/components/Plots/Column/Column.stories.tsx
+++ b/packages/react/src/lib/components/Plots/Column/Column.stories.tsx
@@ -6,6 +6,7 @@ import React from "react";
 
 import { sales_records_dataset } from "../../../../data/sales_records_dataset";
 import { argTypes } from "../../../../storybook/argTypes";
+import { jitterFields, withDataControls } from "../../../../storybook/dataControls";
 import { createCanvasTest, createSVGTest } from "../../../testUtils";
 import { XAxis, YAxis } from "../../Axis";
 import { XYChart } from "../../XYChart";
@@ -50,9 +51,31 @@ export default {
 
 const data = uniqBy(sales_records_dataset, (d) => d["Item Type"]);
 
+// Numeric fields to animate; "Item Type" and the other descriptive fields stay untouched.
+const salesFields = ["Units Sold", "Unit Price", "Unit Cost", "Total Revenue", "Total Cost", "Total Profit"];
+
+function nextSalesRow(current: typeof data) {
+  const usedTypes = new Set(current.map((d) => d["Item Type"]));
+  const candidate = sales_records_dataset.find((d) => !usedTypes.has(d["Item Type"]));
+  if (candidate) {
+    return candidate;
+  }
+  // Every Item Type from the source dataset is already represented - clone a random row under a
+  // synthetic label instead, so the chart still gains a visibly new category
+  const base = current[Math.floor(Math.random() * current.length)];
+  return jitterFields({ ...base, "Item Type": `${base["Item Type"]} (New)` }, salesFields, 0.3);
+}
+
+const salesDataControls = {
+  initialData: data,
+  randomize: (row: (typeof data)[number]) => jitterFields(row, salesFields, 0.3),
+  createPoint: nextSalesRow,
+  minLength: 2,
+};
+
 const ColumnTemplate = (args) => (
   <XYChart
-    data={data}
+    data={args.data ?? data}
     plotMargin={{
       left: args.leftMargin,
       right: args.rightMargin,
@@ -74,6 +97,8 @@ const ColumnTemplate = (args) => (
     {args.y2 && <Column x={args.x} y={args.y2} color={args.color2} />}
   </XYChart>
 );
+
+const ColumnTemplateWithControls = withDataControls(ColumnTemplate, salesDataControls);
 
 const ColumnsTemplate = (args) => (
   <XYChart
@@ -106,7 +131,7 @@ const ColumnsTemplate = (args) => (
 
 export const Basic = {
   name: "Basic Plot",
-  render: ColumnTemplate,
+  render: ColumnTemplateWithControls,
   args: {
     useCanvas: false,
     width: 800,
@@ -135,7 +160,7 @@ export const Color = {
 
 export const Canvas = {
   name: "Using Canvas",
-  render: ColumnTemplate,
+  render: ColumnTemplateWithControls,
   args: {
     ...Basic.args,
     useCanvas: true,

--- a/packages/react/src/lib/components/Plots/Line/Line.stories.tsx
+++ b/packages/react/src/lib/components/Plots/Line/Line.stories.tsx
@@ -4,6 +4,7 @@ import React from "react";
 
 import { waves } from "../../../../data/waves";
 import { argTypes } from "../../../../storybook/argTypes";
+import { jitterFields, withDataControls } from "../../../../storybook/dataControls";
 import { createEventReceiverTest } from "../../../testUtils";
 import { XAxis, YAxis } from "../../Axis";
 import { XYChart } from "../../XYChart";
@@ -47,7 +48,7 @@ export default {
 
 const LineTemplate = (args) => (
   <XYChart
-    data={waves}
+    data={args.data ?? waves}
     plotMargin={{
       left: args.leftMargin,
       right: args.rightMargin,
@@ -75,6 +76,32 @@ const LineTemplate = (args) => (
     <XAxis fields={[args.x]} />
   </XYChart>
 );
+
+// Wave field names that carry values to animate; "x" stays untouched so points remain ordered.
+const waveFields = ["sin", "cos", "tan", "sinh", "cosh"];
+
+function nextWavePoint(current: typeof waves) {
+  const last = current[current.length - 1] ?? waves[0];
+  const x = last.x + 10;
+  const rad = x * (Math.PI / 180);
+  return {
+    x,
+    sin: Math.sin(rad),
+    cos: Math.cos(rad),
+    tan: Math.tan(rad),
+    sinh: Math.sinh(rad),
+    cosh: Math.cosh(rad),
+  };
+}
+
+const waveDataControls = {
+  initialData: waves,
+  randomize: (row: (typeof waves)[number]) => jitterFields(row, waveFields, 0.3),
+  createPoint: nextWavePoint,
+  minLength: 5,
+};
+
+const LineTemplateWithControls = withDataControls(LineTemplate, waveDataControls);
 
 const LinesTemplate = (args) => (
   <XYChart
@@ -104,7 +131,7 @@ const LinesTemplate = (args) => (
 
 export const Basic = {
   name: "Basic Plot",
-  render: LineTemplate,
+  render: LineTemplateWithControls,
   args: {
     useCanvas: false,
     width: 800,
@@ -150,7 +177,7 @@ export const Color = {
 
 export const Canvas = {
   name: "Using Canvas",
-  render: LineTemplate,
+  render: LineTemplateWithControls,
   args: {
     ...Basic.args,
     useCanvas: true,

--- a/packages/react/src/lib/components/Plots/Pie/Pie.stories.tsx
+++ b/packages/react/src/lib/components/Plots/Pie/Pie.stories.tsx
@@ -6,6 +6,7 @@ import React from "react";
 
 import { gdp_dataset } from "../../../../data/gdp_dataset";
 import { argTypes } from "../../../../storybook/argTypes";
+import { jitterFields, withDataControls } from "../../../../storybook/dataControls";
 import { createCanvasTest, createSVGTest } from "../../../testUtils";
 import { RadialChart } from "../../RadialChart";
 import { Donut } from "./Donut";
@@ -51,9 +52,22 @@ const data = Array.from(
     ([continent, gdp]) => ({ continent, gdp }),
 );
 
+// Continent GDP is fully aggregated already, so there's nothing left to randomize but the value.
+const pieDataControls = {
+    initialData: data,
+    randomize: (row: (typeof data)[number]) => jitterFields(row, ["gdp"], 0.3),
+    // Every continent in the source dataset is already represented - clone a random slice under a
+    // synthetic label instead, so the chart still gains a visibly new slice
+    createPoint: (current: typeof data) => {
+        const base = current[Math.floor(Math.random() * current.length)];
+        return jitterFields({ ...base, continent: `${base.continent} (New)` }, ["gdp"], 0.3);
+    },
+    minLength: 2,
+};
+
 const PieTemplate = (args) => (
     <RadialChart
-        data={data}
+        data={args.data ?? data}
         plotMargin={{
             left: args.leftMargin,
             right: args.rightMargin,
@@ -72,6 +86,8 @@ const PieTemplate = (args) => (
         <Pie category={args.category} value={args.value} sort={args.sort} />
     </RadialChart>
 );
+
+const PieTemplateWithControls = withDataControls(PieTemplate, pieDataControls);
 
 const DonutTemplate = (args) => (
     <RadialChart
@@ -98,7 +114,7 @@ const DonutTemplate = (args) => (
 
 export const Basic = {
     name: "Basic Plot",
-    render: PieTemplate,
+    render: PieTemplateWithControls,
     args: {
         useCanvas: false,
         width: 800,
@@ -117,7 +133,7 @@ export const Basic = {
 
 export const Canvas = {
     name: "Using Canvas",
-    render: PieTemplate,
+    render: PieTemplateWithControls,
     args: {
         ...Basic.args,
         useCanvas: true,

--- a/packages/react/src/lib/components/Plots/Pie/StackedDonut.stories.tsx
+++ b/packages/react/src/lib/components/Plots/Pie/StackedDonut.stories.tsx
@@ -6,6 +6,7 @@ import React from "react";
 
 import { gdp_dataset } from "../../../../data/gdp_dataset";
 import { argTypes } from "../../../../storybook/argTypes";
+import { jitterFields, withDataControls } from "../../../../storybook/dataControls";
 import { createCanvasTest, createSVGTest } from "../../../testUtils";
 import { RadialChart } from "../../RadialChart";
 import { StackedDonut } from "./StackedDonut";
@@ -52,6 +53,18 @@ const fourLevelData = gdp_dataset.flatMap((d) => [
     { ...d, half: "H2", gdp: Math.round(d.gdp * 0.55) },
 ]);
 
+const stackedDonutDataControls = {
+    initialData: data,
+    randomize: (row: (typeof data)[number]) => jitterFields(row, ["gdp"], 0.3),
+    // Clones a random existing row under a synthetic country name, since every continent/country
+    // pairing in the source dataset is already represented
+    createPoint: (current: typeof data) => {
+        const base = current[Math.floor(Math.random() * current.length)];
+        return jitterFields({ ...base, country: `${base.country} (New)` }, ["gdp"], 0.3);
+    },
+    minLength: 6,
+};
+
 const StackedDonutTemplate = (args) => (
     <RadialChart
         data={args.data ?? data}
@@ -75,9 +88,11 @@ const StackedDonutTemplate = (args) => (
     </RadialChart>
 );
 
+const StackedDonutTemplateWithControls = withDataControls(StackedDonutTemplate, stackedDonutDataControls);
+
 export const Basic = {
     name: "Basic Plot",
-    render: StackedDonutTemplate,
+    render: StackedDonutTemplateWithControls,
     args: {
         useCanvas: false,
         width: 800,
@@ -96,7 +111,7 @@ export const Basic = {
 
 export const Canvas = {
     name: "Using Canvas",
-    render: StackedDonutTemplate,
+    render: StackedDonutTemplateWithControls,
     args: {
         ...Basic.args,
         useCanvas: true,

--- a/packages/react/src/lib/components/Plots/Radar/Radar.stories.tsx
+++ b/packages/react/src/lib/components/Plots/Radar/Radar.stories.tsx
@@ -5,6 +5,7 @@ import { fn } from "@storybook/test";
 import React from "react";
 
 import { argTypes } from "../../../../storybook/argTypes";
+import { jitterFields, withDataControls } from "../../../../storybook/dataControls";
 import { createCanvasTest, createSVGTest } from "../../../testUtils";
 import { AngleAxis, RadialAxis } from "../../Axis";
 import { RadialChart } from "../../RadialChart";
@@ -54,6 +55,28 @@ const manyPlayers = [
     { player: "Player E", Speed: 90, Power: 45, Defense: 60, Stamina: 50, Agility: 85 },
 ];
 
+function nextPlayer(current: typeof twoPlayers) {
+    const letter = String.fromCharCode(65 + current.length);
+    const values = Object.fromEntries(skills.map((skill) => [skill, Math.round(40 + Math.random() * 55)]));
+    return { player: `Player ${letter}`, ...values } as (typeof twoPlayers)[number];
+}
+
+function jitterSkills(row: (typeof twoPlayers)[number]) {
+    const jittered = jitterFields(row, skills, 0.2);
+    // Keep every skill within the radar's 0-100 domain after jittering
+    for (const skill of skills) {
+        jittered[skill] = Math.min(100, Math.max(0, Math.round(jittered[skill])));
+    }
+    return jittered;
+}
+
+const radarDataControls = {
+    initialData: twoPlayers,
+    randomize: jitterSkills,
+    createPoint: nextPlayer,
+    minLength: 1,
+};
+
 const RadarTemplate = (args) => (
     <RadialChart
         data={args.data}
@@ -80,9 +103,11 @@ const RadarTemplate = (args) => (
     </RadialChart>
 );
 
+const RadarTemplateWithControls = withDataControls(RadarTemplate, radarDataControls);
+
 export const Basic = {
     name: "Basic Plot",
-    render: RadarTemplate,
+    render: RadarTemplateWithControls,
     args: {
         useCanvas: false,
         width: 800,
@@ -103,7 +128,7 @@ export const Basic = {
 
 export const Canvas = {
     name: "Using Canvas",
-    render: RadarTemplate,
+    render: RadarTemplateWithControls,
     args: {
         ...Basic.args,
         useCanvas: true,

--- a/packages/react/src/lib/components/Plots/RadialArea/RadialArea.stories.tsx
+++ b/packages/react/src/lib/components/Plots/RadialArea/RadialArea.stories.tsx
@@ -5,6 +5,7 @@ import { fn } from "@storybook/test";
 import React from "react";
 
 import { argTypes } from "../../../../storybook/argTypes";
+import { jitterFields, withDataControls } from "../../../../storybook/dataControls";
 import { createEventReceiverTest } from "../../../testUtils";
 import { AngleAxis, RadialAxis } from "../../Axis";
 import { RadialChart } from "../../RadialChart";
@@ -56,6 +57,26 @@ const twoCities = buildYearOfTemperatures(0, 12, 15).map((d, i) => ({
     // A milder, less seasonally-varied climate for comparison
     Miami: Math.max(0, Math.round((24 - 6 * Math.cos((2 * Math.PI * i) / 365) + Math.sin(i * 0.15) * 1.5) * 10) / 10),
 }));
+
+function nextDay(current: typeof singleCity) {
+    const last = current[current.length - 1] ?? singleCity[0];
+    const date = new Date(last.date);
+    date.setDate(date.getDate() + 1);
+    const temperature = Math.max(0, Math.round((last.temperature + (Math.random() * 4 - 2)) * 10) / 10);
+    return { date, temperature };
+}
+
+function jitterTemperature(row: (typeof singleCity)[number]) {
+    const jittered = jitterFields(row, ["temperature"], 0.15);
+    return { ...jittered, temperature: Math.max(0, jittered.temperature) };
+}
+
+const radialAreaDataControls = {
+    initialData: singleCity,
+    randomize: jitterTemperature,
+    createPoint: nextDay,
+    minLength: 30,
+};
 
 const RadialAreaTemplate = (args) => (
     <RadialChart
@@ -109,9 +130,11 @@ const MultiSeriesTemplate = (args) => (
     </RadialChart>
 );
 
+const RadialAreaTemplateWithControls = withDataControls(RadialAreaTemplate, radialAreaDataControls);
+
 export const Basic = {
     name: "Basic Plot",
-    render: RadialAreaTemplate,
+    render: RadialAreaTemplateWithControls,
     args: {
         useCanvas: false,
         width: 800,
@@ -129,7 +152,7 @@ export const Basic = {
 
 export const Canvas = {
     name: "Using Canvas",
-    render: RadialAreaTemplate,
+    render: RadialAreaTemplateWithControls,
     args: {
         ...Basic.args,
         useCanvas: true,

--- a/packages/react/src/lib/components/Plots/Scatter/Scatter.stories.tsx
+++ b/packages/react/src/lib/components/Plots/Scatter/Scatter.stories.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { huge_data_set } from "../../../../data/huge_data_set";
 import { sales_records_dataset } from "../../../../data/sales_records_dataset";
 import { argTypes } from "../../../../storybook/argTypes";
+import { jitterFields, withDataControls } from "../../../../storybook/dataControls";
 import { createCanvasTest, createSVGTest } from "../../../testUtils";
 import { XAxis, YAxis } from "../../Axis";
 import { XYChart } from "../../XYChart";
@@ -80,6 +81,21 @@ const ScatterTemplate = (args) => (
   </XYChart>
 );
 
+// Numeric fields to animate; the rest (Country, Item Type, dates, ...) stay untouched.
+const salesFields = ["Units Sold", "Unit Price", "Unit Cost", "Total Revenue", "Total Cost", "Total Profit"];
+
+const scatterDataControls = {
+  initialData: sales_records_dataset,
+  randomize: (row: (typeof sales_records_dataset)[number]) => jitterFields(row, salesFields, 0.3),
+  // Clones a random existing row and jitters it, since the source dataset is small enough that
+  // Basic already includes every row
+  createPoint: (current: typeof sales_records_dataset) =>
+    jitterFields(current[Math.floor(Math.random() * current.length)], salesFields, 0.3),
+  minLength: 5,
+};
+
+const ScatterTemplateWithControls = withDataControls(ScatterTemplate, scatterDataControls);
+
 const ScattersTemplate = (args) => (
   <XYChart
     plotMargin={{
@@ -106,7 +122,7 @@ const ScattersTemplate = (args) => (
 
 export const Basic = {
   name: "Basic Plot",
-  render: ScatterTemplate,
+  render: ScatterTemplateWithControls,
   args: {
     useCanvas: false,
     width: 800,
@@ -146,7 +162,7 @@ export const Color = {
 
 export const Canvas = {
   name: "Using Canvas",
-  render: ScatterTemplate,
+  render: ScatterTemplateWithControls,
   args: {
     ...Basic.args,
     useCanvas: true,

--- a/packages/react/src/lib/components/Plots/Treemap.stories.tsx
+++ b/packages/react/src/lib/components/Plots/Treemap.stories.tsx
@@ -6,6 +6,7 @@ import React from "react";
 
 import { gdp_dataset } from "../../../data/gdp_dataset";
 import { argTypes } from "../../../storybook/argTypes";
+import { jitterFields, withDataControls } from "../../../storybook/dataControls";
 import { createCanvasTest, createSVGTest } from "../../testUtils";
 import { Treemap } from "./Treemap";
 
@@ -51,6 +52,18 @@ const fourLevelData = gdp_dataset.flatMap((d) => [
     { ...d, half: "H2", gdp: Math.round(d.gdp * 0.55) },
 ]);
 
+const treemapDataControls = {
+    initialData: data,
+    randomize: (row: (typeof data)[number]) => jitterFields(row, ["gdp"], 0.3),
+    // Clones a random existing row under a synthetic country name, since every continent/country
+    // pairing in the source dataset is already represented
+    createPoint: (current: typeof data) => {
+        const base = current[Math.floor(Math.random() * current.length)];
+        return jitterFields({ ...base, country: `${base.country} (New)` }, ["gdp"], 0.3);
+    },
+    minLength: 6,
+};
+
 const TreemapTemplate = (args) => (
     <Treemap
         data={args.data ?? data}
@@ -77,9 +90,11 @@ const TreemapTemplate = (args) => (
     />
 );
 
+const TreemapTemplateWithControls = withDataControls(TreemapTemplate, treemapDataControls);
+
 export const Basic = {
     name: "Basic Plot",
-    render: TreemapTemplate,
+    render: TreemapTemplateWithControls,
     args: {
         useCanvas: false,
         width: 800,
@@ -102,7 +117,7 @@ export const Basic = {
 
 export const Canvas = {
     name: "Using Canvas",
-    render: TreemapTemplate,
+    render: TreemapTemplateWithControls,
     args: {
         ...Basic.args,
         useCanvas: true,

--- a/packages/react/src/storybook/dataControls.tsx
+++ b/packages/react/src/storybook/dataControls.tsx
@@ -1,3 +1,4 @@
+import isChromatic from "chromatic";
 import React, { useState } from "react";
 
 // Storybook-only helpers for exercising a chart's enter/update/exit animations by hand. Not part
@@ -93,6 +94,11 @@ export function DataControls({
 // The controls sit *after* the chart in a flex row (not above it) so the chart's own bounding box
 // - and so the fixed clientX/clientY coordinates the play() interaction tests click at - never
 // moves, regardless of whether the controls are present.
+//
+// Chromatic captures whatever's on the page, and these buttons are a Storybook-only dev aid, not
+// part of what a visual regression snapshot should cover - so under Chromatic this renders nothing
+// but the chart itself (identical to the un-wrapped story), and the buttons only appear when
+// browsing Storybook normally.
 export function withDataControls<T, A extends { data?: T[] }>(
   Template: (args: A) => JSX.Element,
   config: DataControlsConfig<T>,
@@ -102,6 +108,11 @@ export function withDataControls<T, A extends { data?: T[] }>(
       ...config,
       initialData: args.data ?? config.initialData,
     });
+
+    if (isChromatic()) {
+      return <Template {...args} data={data} />;
+    }
+
     return (
       <div style={{ display: "flex", alignItems: "flex-start", gap: 16 }}>
         <Template {...args} data={data} />

--- a/packages/react/src/storybook/dataControls.tsx
+++ b/packages/react/src/storybook/dataControls.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from "react";
+
+// Storybook-only helpers for exercising a chart's enter/update/exit animations by hand. Not part
+// of the public library - used to wrap the "Basic Plot"/"Canvas" stories with buttons that mutate
+// their underlying data.
+
+function jitter(value: number, amount: number): number {
+  return value + (Math.random() * 2 - 1) * amount * Math.max(Math.abs(value), 1);
+}
+
+// Nudges every listed numeric field on a row by a random +/- `amount` fraction of its own
+// magnitude, leaving any other fields (categories, dates, ids) untouched.
+export function jitterFields<T extends Record<string, unknown>>(
+  row: T,
+  fields: readonly string[],
+  amount = 0.2,
+): T {
+  const next = { ...row };
+  for (const field of fields) {
+    const value = next[field];
+    if (typeof value === "number") {
+      (next as Record<string, unknown>)[field] = jitter(value, amount);
+    }
+  }
+  return next;
+}
+
+export interface DataControlsConfig<T> {
+  initialData: T[];
+  randomize: (row: T) => T;
+  createPoint: (data: T[]) => T;
+  // Smallest array length `removePoint` will reduce down to, so a chart never animates to empty.
+  minLength?: number;
+}
+
+export function useDataControls<T>(config: DataControlsConfig<T>) {
+  const [data, setData] = useState(config.initialData);
+  const minLength = config.minLength ?? 1;
+
+  const randomizeValues = () => setData((current) => current.map(config.randomize));
+
+  const addPoint = () => setData((current) => [...current, config.createPoint(current)]);
+
+  const removePoint = () =>
+    setData((current) => {
+      if (current.length <= minLength) {
+        return current;
+      }
+      const index = Math.floor(Math.random() * current.length);
+      return current.filter((_, i) => i !== index);
+    });
+
+  return { data, randomizeValues, addPoint, removePoint };
+}
+
+const buttonStyle: React.CSSProperties = {
+  padding: "6px 12px",
+  border: "1px solid #99C1DC",
+  borderRadius: 4,
+  background: "#fff",
+  cursor: "pointer",
+  fontSize: 13,
+  whiteSpace: "nowrap",
+};
+
+export function DataControls({
+  onRandomize,
+  onAdd,
+  onRemove,
+}: {
+  onRandomize: () => void;
+  onAdd: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <button type="button" style={buttonStyle} onClick={onRandomize}>
+        Randomize Values
+      </button>
+      <button type="button" style={buttonStyle} onClick={onAdd}>
+        Add Data Point
+      </button>
+      <button type="button" style={buttonStyle} onClick={onRemove}>
+        Remove Random Point
+      </button>
+    </div>
+  );
+}
+
+// Wraps a story's render template so it owns its own copy of `config.initialData` (seeded from
+// `args.data` when the story already parameterizes it) and renders the three controls beside it.
+//
+// The controls sit *after* the chart in a flex row (not above it) so the chart's own bounding box
+// - and so the fixed clientX/clientY coordinates the play() interaction tests click at - never
+// moves, regardless of whether the controls are present.
+export function withDataControls<T, A extends { data?: T[] }>(
+  Template: (args: A) => JSX.Element,
+  config: DataControlsConfig<T>,
+) {
+  return function TemplateWithDataControls(args: A) {
+    const { data, randomizeValues, addPoint, removePoint } = useDataControls({
+      ...config,
+      initialData: args.data ?? config.initialData,
+    });
+    return (
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 16 }}>
+        <Template {...args} data={data} />
+        <DataControls onRandomize={randomizeValues} onAdd={addPoint} onRemove={removePoint} />
+      </div>
+    );
+  };
+}


### PR DESCRIPTION
## Summary

- Adds three buttons - **Randomize Values**, **Add Data Point**, **Remove Random Point** - to the `Basic Plot` and `Using Canvas` story variants of every XY/Radial chart in the React package (Line, Area, Bar, Column, Scatter, Pie, StackedDonut, Radar, RadialArea, Treemap), so update/enter/exit animations can be exercised by hand instead of only via static Storybook args.
- Introduces a shared `packages/react/src/storybook/dataControls.tsx` helper: a `useDataControls` hook that owns a local copy of the story's dataset, a `DataControls` button row, `jitterFields` (nudges chosen numeric fields by a random +/- fraction), and a `withDataControls` wrapper that seeds itself from the story's existing dataset/`args.data`.
- Each file gets a small dataset-specific config (which fields to jitter, how to synthesize a new row, a floor on how far "remove" can shrink the array) since the shapes differ (wave series, sales records, GDP-by-continent, radar skill rows, etc.).
- The controls render in a flex row *beside* the chart rather than above it, so the chart's own bounding box - and the fixed `clientX`/`clientY` coordinates the existing `play()` interaction tests click at - are unaffected.

Out of scope (left untouched): non-Basic/Canvas story variants (Color, Stacked, Grouped, etc.), non-data stories (Axis, Legend, Tooltip, Shapes...), and `MixedPlots.stories.tsx`, which doesn't follow the `Basic`/`Canvas` export convention the other files use.

## Test plan

- [x] `npm run types` (tsc --noEmit) passes in `packages/react`
- [x] `npm run lint` (eslint) passes in `packages/react`
- [x] Manually verified in a running Storybook via Playwright: buttons render on Line/Bar/Pie/Radar/StackedDonut/Treemap/Scatter/RadialArea Basic stories; Add/Remove change the underlying data (point/bar/slice/marker counts move up and down by one); Randomize visibly perturbs the chart; the chart's SVG bounding box is identical before/after interacting, so the existing coordinate-based `play()` tests still target the right pixels
- [x] Spot-checked the Canvas variant (Line) renders via `<canvas>` as before

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01H8qsK4tSRjyqW6aNu1vfEr

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8qsK4tSRjyqW6aNu1vfEr)_