### PR TITLE
Style Axis titles using the theme

### DIFF
--- a/.changeset/axis-title-theme.md
+++ b/.changeset/axis-title-theme.md
@@ -1,0 +1,6 @@
+---
+"@chart-io/react": patch
+"@chart-io/svelte": patch
+---
+
+Fixed Axis titles (`<XAxis title="...">`, `<YAxis title="...">`) not picking up the chart's theme - the title text always rendered at a fixed 14px in the browser's default black fill, regardless of the active theme, so it could look inconsistent with the rest of the axis (which does use the theme) or hard to read against a dark background. The title now uses `theme.axis.stroke` for its fill and `theme.font.family`/`theme.font.size` for its typography, matching the tick labels.

--- a/packages/react/src/lib/components/Axis/Axis/Title/Title.tsx
+++ b/packages/react/src/lib/components/Axis/Axis/Title/Title.tsx
@@ -10,6 +10,7 @@ export function Title({ position, title }: ITitleProps) {
     const plotWidth = useSelector((s: IState) => chartSelectors.dimensions.plot.width(s));
     const plotHeight = useSelector((s: IState) => chartSelectors.dimensions.plot.height(s));
     const plotMargin = useSelector((s: IState) => chartSelectors.dimensions.plot.margin(s));
+    const theme = useSelector((s: IState) => chartSelectors.theme(s));
 
     const transform = getTransform(position, plotWidth, plotHeight, plotMargin);
 
@@ -19,7 +20,9 @@ export function Title({ position, title }: ITitleProps) {
 
     const style = {
         textAnchor: "middle" as const,
-        fontSize: 14,
+        fontSize: theme.font.size,
+        fontFamily: theme.font.family,
+        fill: theme.axis.stroke.toString(),
         userSelect: "none" as const,
     };
 

--- a/packages/react/src/lib/components/Axis/Axis/Title/__snapshots__/Title.unit.tsx.snap
+++ b/packages/react/src/lib/components/Axis/Axis/Title/__snapshots__/Title.unit.tsx.snap
@@ -11,7 +11,7 @@ exports[`Title component with title set renders horizontal title 1`] = `
   <svg>
     <text
       class="chart-io axis-title axis-title-bottom"
-      style="text-anchor: middle; font-size: 14px; user-select: none;"
+      style="text-anchor: middle; font-size: 12px; font-family: sans-serif; fill: #333333; user-select: none;"
       transform="translate(470, 495)"
     >
       horizontal
@@ -25,7 +25,7 @@ exports[`Title component with title set renders vertical title 1`] = `
   <svg>
     <text
       class="chart-io axis-title axis-title-left"
-      style="text-anchor: middle; font-size: 14px; user-select: none;"
+      style="text-anchor: middle; font-size: 12px; font-family: sans-serif; fill: #333333; user-select: none;"
       transform="translate(0, 230)rotate(270)"
     >
       vertical

--- a/packages/react/src/lib/components/Axis/Axis/__snapshots__/Axis.unit.tsx.snap
+++ b/packages/react/src/lib/components/Axis/Axis/__snapshots__/Axis.unit.tsx.snap
@@ -8,7 +8,7 @@ exports[`Axis component renders a bottom axis 1`] = `
     >
       <text
         class="chart-io axis-title axis-title-left"
-        style="text-anchor: middle; font-size: 14px; user-select: none;"
+        style="text-anchor: middle; font-size: 12px; font-family: sans-serif; fill: #333333; user-select: none;"
         transform="translate(-20, 230)rotate(270)"
       >
         x
@@ -208,7 +208,7 @@ exports[`Axis component renders a left axis 1`] = `
     >
       <text
         class="chart-io axis-title axis-title-left"
-        style="text-anchor: middle; font-size: 14px; user-select: none;"
+        style="text-anchor: middle; font-size: 12px; font-family: sans-serif; fill: #333333; user-select: none;"
         transform="translate(-20, 230)rotate(270)"
       >
         y
@@ -408,7 +408,7 @@ exports[`Axis component renders a right axis 1`] = `
     >
       <text
         class="chart-io axis-title axis-title-right"
-        style="text-anchor: middle; font-size: 14px; user-select: none;"
+        style="text-anchor: middle; font-size: 12px; font-family: sans-serif; fill: #333333; user-select: none;"
         transform="translate(1015, 230)rotate(270)"
       >
         y
@@ -608,7 +608,7 @@ exports[`Axis component renders a top axis 1`] = `
     >
       <text
         class="chart-io axis-title axis-title-top"
-        style="text-anchor: middle; font-size: 14px; user-select: none;"
+        style="text-anchor: middle; font-size: 12px; font-family: sans-serif; fill: #333333; user-select: none;"
         transform="translate(490, 5)"
       >
         x

--- a/packages/svelte/src/lib/components/Axis/Axis/Title/Title.svelte
+++ b/packages/svelte/src/lib/components/Axis/Axis/Title/Title.svelte
@@ -10,6 +10,7 @@
     let plotWidth = useSelector((s: IState) => chartSelectors.dimensions.plot.width(s));
     let plotHeight = useSelector((s: IState) => chartSelectors.dimensions.plot.height(s));
     let plotMargin = useSelector((s: IState) => chartSelectors.dimensions.plot.margin(s));
+    let theme = useSelector((s: IState) => chartSelectors.theme(s));
 
     $: transform = getTransform(position, $plotWidth, $plotHeight, $plotMargin);
 </script>
@@ -18,7 +19,7 @@
     <text
         class={`chart-io axis-title axis-title-${position}`}
         {transform}
-        style="text-anchor: middle; font-size: 14px; user-select: none"
+        style="text-anchor: middle; font-size: {$theme.font.size}px; font-family: {$theme.font.family}; fill: {$theme.axis.stroke}; user-select: none"
     >
         {title}
     </text>


### PR DESCRIPTION
## Summary
- Axis titles (`<XAxis title="...">` / `<YAxis title="...">`) previously rendered with a hardcoded 14px font in the browser's default black fill, completely ignoring the chart's theme
- This made them inconsistent with the axis tick labels (which already respect `theme.axis.stroke`), and unreadable/"weird" looking against a dark theme's background
- The `Title` component (React and Svelte) now pulls the current theme and applies `theme.axis.stroke` as the fill, and `theme.font.family` / `theme.font.size` for the typography, matching the rest of the axis

## Test plan
- [x] `pnpm exec jest` in `packages/react` - all 72 suites / 307 tests pass, snapshots updated to reflect the new themed styles
- [x] `pnpm exec tsc --noEmit` in `packages/react` - no type errors
- [x] `pnpm exec vitest run` in `packages/svelte` - all 13 suites / 37 tests pass
- [x] Added a changeset for `@chart-io/react` and `@chart-io/svelte`

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeST1SV8Z2Dvpcy44BrpnX)_