### PR TITLE
Fix Radial axis animating in from center and story-switching crash

### DIFF
--- a/.changeset/radial-axis-animation-and-freeze-fix.md
+++ b/.changeset/radial-axis-animation-and-freeze-fix.md
@@ -1,0 +1,8 @@
+---
+"@chart-io/core": patch
+"@chart-io/react": patch
+---
+
+Fixed `<AngleAxis>`/`<RadialAxis>` spokes, rings and labels animating in from the center (0,0) on a `<Radar>`/`<RadialArea>`'s very first render - they now appear directly at their final position, and only animate when moving between two real positions on a later update.
+
+Fixed `state.data = [...action.payload]` no longer aliasing the caller's own data array into the Redux store. Immer freezes anything reachable from the store's state, so a caller's own array (e.g. a Storybook story's shared `args.data`) previously became frozen as a side effect of being passed to a chart, breaking any other code (including Storybook's own args handling) that still expected to be able to write to it - most visibly as `Cannot assign to read only property '0' of object '[object Array]'` when switching between Radial chart stories that reused the same data.

--- a/packages/core/src/store/chart/chartSlice.ts
+++ b/packages/core/src/store/chart/chartSlice.ts
@@ -195,7 +195,11 @@ const chartSlice = createSlice({
          * @param action                     The payload containing the data for the chart
          */
         setChartData: (state: IChartState, action: PayloadAction<IData>) => {
-            state.data = action.payload;
+            // Copy rather than reference the caller's array directly - Immer deep-freezes everything
+            // reachable from the new state once this is assigned, and freezing the caller's own array
+            // (rather than just this copy of it) breaks anything else still holding that same
+            // reference and expecting to be able to write to it (e.g. Storybook's own args handling)
+            state.data = action.payload ? [...action.payload] : action.payload;
         },
 
         /**

--- a/packages/react/src/lib/components/Axis/AngleAxis/AngleAxis.tsx
+++ b/packages/react/src/lib/components/Axis/AngleAxis/AngleAxis.tsx
@@ -113,8 +113,19 @@ function AxisSpoke({
         join.exit().remove();
 
         const enter = join.enter().append("g").attr("class", "angle-axis-tick");
-        enter.append("line").attr("class", "angle-axis-spoke");
-        enter.append("text").attr("class", "angle-axis-label");
+        // Entering spokes/labels start at their final position rather than the SVG attribute
+        // defaults (x2/y2/x/y all 0) - only pre-existing ticks that are moving to a new position
+        // should animate, not ones appearing for the first time
+        enter
+            .append("line")
+            .attr("class", "angle-axis-spoke")
+            .attr("x2", (d) => cx + maxRadius * Math.sin(angleOf(d)))
+            .attr("y2", (d) => cy - maxRadius * Math.cos(angleOf(d)));
+        enter
+            .append("text")
+            .attr("class", "angle-axis-label")
+            .attr("x", (d) => cx + (maxRadius + tickPadding) * Math.sin(angleOf(d)))
+            .attr("y", (d) => cy - (maxRadius + tickPadding) * Math.cos(angleOf(d)));
 
         const update = enter.merge(join as any);
 

--- a/packages/react/src/lib/components/Axis/RadialAxis/RadialAxis.tsx
+++ b/packages/react/src/lib/components/Axis/RadialAxis/RadialAxis.tsx
@@ -142,8 +142,20 @@ function RadialAxisRing({
         join.exit().remove();
 
         const enter = join.enter().append("g").attr("class", "radial-axis-tick");
-        enter.append("circle").attr("class", "radial-axis-ring");
-        enter.append("text").attr("class", "radial-axis-label");
+        // Entering rings/labels start at their final position rather than the SVG attribute
+        // defaults (r=0, x=0/y=0) - only pre-existing ticks that are moving to a new position
+        // should animate, not ones appearing for the first time
+        enter
+            .append("circle")
+            .attr("class", "radial-axis-ring")
+            .attr("cx", cx)
+            .attr("cy", cy)
+            .attr("r", (d) => Math.max(0, scaleOf(d)));
+        enter
+            .append("text")
+            .attr("class", "radial-axis-label")
+            .attr("x", cx)
+            .attr("y", (d) => cy - Math.max(0, scaleOf(d)));
 
         const update = enter.merge(join as any);
 


### PR DESCRIPTION
## Summary

- Fixed `<AngleAxis>`/`<RadialAxis>` spokes, rings and labels animating in from the center (0,0) on a `<Radar>`/`<RadialArea>`'s very first render. Entering elements previously had no prior attribute value for the D3 transition to start from (defaulting to `0`), so they visibly grew/swept in from the middle. They now get their final position set immediately on enter and only animate when an *existing* tick moves to a new position on a later update.
- Fixed the `TypeError: Cannot assign to read only property '0' of object '[object Array]'` crash reported when switching between Radial chart Storybook stories (e.g. navigating from the Radar docs page to `Radar Basic Plot`, or between Radar/RadialArea stories that share the same underlying data array).

## Root cause of the crash

`chartSlice`'s `setChartData` reducer assigned the caller's `data` array directly into Redux state (`state.data = action.payload`). Since chart-io's store uses Redux Toolkit/Immer, Immer deep-freezes everything reachable from the new state once a `produce` call finishes - including that original array reference, not just the store's own copy of it.

Storybook stories commonly reuse the same module-level data array across several sibling stories (e.g. `Basic`/`Canvas`/`SingleSeries` all pointing at the same `twoPlayers` array via `args.data`). Once any one of those stories mounted a chart and that array got frozen as a side effect, any other code still holding that same reference - including Storybook's own internal `@storybook/test` loader (`nameSpiesAndWrapActionsInSpies` → `traverseArgs`), which walks a story's `args` and writes back into any array it finds - would throw trying to write into it on the next render.

Verified locally by running Storybook and reproducing the exact crash by navigating the sidebar the way the report described (Radar docs → Basic Plot → Using Canvas → back to docs), then confirming it's gone after the fix. Full Jest suite (`pnpm test`) passes for both `@chart-io/core` and `@chart-io/react`.

## Test plan

- [x] `pnpm --filter @chart-io/core test` passes
- [x] `pnpm --filter @chart-io/react test` passes (333/333)
- [x] Reproduced the reported crash in a local Storybook instance by clicking through Radar/RadialArea stories, confirmed it no longer occurs after the fix
- [x] Verified via DOM inspection that entering axis rings/spokes render at their final position immediately (no growth-from-center on first mount) while update animations (e.g. clicking "Randomize Values") still animate smoothly

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01YMRQHyzERFir6S2pxcWbFR


---
_Generated by [Claude Code](https://claude.ai/code/session_01YMRQHyzERFir6S2pxcWbFR)_