### PR TITLE
Add stack offset/order support and fix mislabelled Stream Graph story

### DIFF
--- a/.changeset/stacked-area-stack-offset-and-order.md
+++ b/.changeset/stacked-area-stack-offset-and-order.md
@@ -1,0 +1,7 @@
+---
+"@chart-io/react": minor
+---
+
+`<StackedArea>` and `<Areas stacked>` now accept `offset` and `order` props to control how the stack's layers are positioned - e.g. `offset="wiggle"` produces a Stream Graph. Previously the stack was always built with a fixed zero baseline (`d3`'s default `stackOffsetNone`/`stackOrderNone`), so a real Stream Graph couldn't be built at all.
+
+This also fixes the Storybook "Stream Graph" example under `<Area>`, which didn't actually render a streamgraph - it rendered a plain `<Area>` with a `y2` band (now correctly relabelled "Range Area"). The real Stream Graph example now lives under `<Areas>`, built with the new `offset="wiggle"` prop.

--- a/packages/react/src/lib/components/Plots/Area/Area.mdx
+++ b/packages/react/src/lib/components/Plots/Area/Area.mdx
@@ -24,16 +24,16 @@ The `<Area>` component should be used when you want to plot a single area plot o
 | -------------- | --------- | ------------------ | ------------------------------------------------------------------------------------------------------------ |
 | **`x`\***      | `string`  | `null`             | The key of the field that contains the value along the x-axis.                                               |
 | **`y`\***      | `string`  | `null`             | The key of the field that contains the value along the y-axis.                                               |
-| `y2`           | `string`  | `null`             | The key of the field that contains the y2 value for a stream graph style.                                    |
+| `y2`           | `string`  | `null`             | The key of the field that contains a second y-value, filling the band between `y` and `y2` (a range area).   |
 | `color`        | `string`  | Derived from Theme | Override the colour of the series                                                                            |
 | `interactive`  | `boolean` | `true`             | Whether the plot should be interactive. Setting this to false will disable tooltips & markers from this plot |
 | `showInLegend` | `boolean` | `true`             | Whether the plot should feature in the legend or not.                                                        |
 | `noClip`       | `boolean` | `false`            | Supress clipping of the plot.                                                                                |
 
-### Stream Graph
+### Range Area
 
 ```javascript
-export const StreamAreaTemplate = (args) => (
+export const RangeAreaTemplate = (args) => (
     <Chart {...args} data={sales_records_dataset}>
         <YAxis fields={[args.y, args.y2]} />
         <XAxis fields={[args.x]} showGridlines={false} />
@@ -49,9 +49,11 @@ export const StreamAreaTemplate = (args) => (
 );
 ```
 
-The `<Area>` component also allows us to represent a Stream plot.
+Providing `y2` on a single `<Area>` fills the band between `y` and `y2`, rather than filling down to the axis - useful for showing a range, such as a min/max band around a line.
 
-<Canvas of={AreaStories.Stream} />
+<Canvas of={AreaStories.RangeArea} />
+
+> **Note**: This is not a Stream Graph, despite the visual similarity of a single wavy band. For an actual Stream Graph - multiple stacked series with a floating baseline - see [Stream Graph](#stream-graph) under `<Areas>` below.
 
 ### Visual Styling
 
@@ -74,6 +76,8 @@ The `<Areas>` component allows us to define multiple area series. There are two 
 | **`ys`\*** | `string[]` | `null`             | The keys of the fields that contains values along the y-axis.        |
 | `colors`   | `string[]` | Derived from Theme | Override the colours for the series                                  |
 | `stacked`  | `boolean`  | `false`            | Whether the plots should be stacked. If false they will be overlayed |
+| `offset`   | `"none" \| "wiggle" \| "silhouette" \| "expand"` | `"none"` | Only applies when `stacked` is true. How the stack's layers are offset from the baseline - `"wiggle"` produces a Stream Graph. |
+| `order`    | `"none" \| "ascending" \| "descending" \| "insideOut" \| "reverse"` | `"none"` | Only applies when `stacked` is true. The order the stack's layers are arranged in - `"insideOut"` is the usual pairing with `offset="wiggle"`. |
 
 ### Overlapping Areas
 
@@ -91,6 +95,23 @@ Another way to to combine area plots is to stack them on top of each other. To s
 The chart will attempt to warn you, but you should also set the `aggregate` field on your X Axis/Scale as otherwise the data will overflow of the top of the scale `<XAxis ... aggregate={true} />`.
 
 <Canvas of={AreaStories.StackedAreas} />
+
+### Stream Graph
+
+A Stream Graph is a stacked area chart with a `"wiggle"` offset - instead of stacking from a zero
+baseline, the baseline floats to minimize how much each layer wiggles, so the bands read as
+flowing ribbons rather than a bar-shaped block. Pair it with `order="insideOut"` to reduce the
+wiggle further.
+
+```javascript
+<Areas x="year" ys={nameFields} stacked={true} offset="wiggle" order="insideOut" />
+```
+
+Because a `"wiggle"` offset can push layers above and below zero, the y-scale's usual `aggregate`
+(zero-to-sum) domain doesn't fit it - provide an explicit `domain` on the `<YAxis>` sized to the
+largest total across your data instead.
+
+<Canvas of={AreaStories.StreamGraph} />
 
 ### Zooming
 

--- a/packages/react/src/lib/components/Plots/Area/Area.stories.tsx
+++ b/packages/react/src/lib/components/Plots/Area/Area.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta } from "@storybook/react";
 import { expect, fn, within } from "@storybook/test";
 import React, { useMemo } from "react";
 
+import { streamData } from "../../../../data/stream_data";
 import { waves } from "../../../../data/waves";
 import { argTypes } from "../../../../storybook/argTypes";
 import { jitterFields, withDataControls } from "../../../../storybook/dataControls";
@@ -145,6 +146,34 @@ const StackedAreasTemplate = (args) => {
   );
 };
 
+// A streamgraph is a stacked area with a `wiggle` offset - it floats the baseline (rather than
+// stacking from zero) so the bands read as flowing ribbons instead of a bar-chart-shaped block
+const streamFields = ["Amanda", "Ashley", "Betty", "Deborah", "Dorothy", "Helen", "Linda", "Patricia"];
+
+// The wiggle offset can push layers above and below zero, so the y-scale's usual `aggregate`
+// (zero-to-sum) domain doesn't fit - it needs an explicit domain sized to the largest yearly total
+const maxStreamTotal = Math.max(...streamData.map((d) => streamFields.reduce((sum, key) => sum + d[key], 0)));
+
+const StreamGraphTemplate = (args) => (
+  <XYChart
+    data={streamData}
+    plotMargin={{
+      left: args.leftMargin,
+      right: args.rightMargin,
+      top: args.topMargin,
+      bottom: args.bottomMargin,
+    }}
+    height={args.height}
+    width={args.width}
+    animationDuration={args.animationDuration}
+    useCanvas={args.useCanvas}
+  >
+    <YAxis fields={streamFields} domain={[-maxStreamTotal, maxStreamTotal]} showGridlines={false} />
+    <XAxis fields={["year"]} />
+    <Areas x="year" ys={streamFields} stacked={true} offset="wiggle" order="insideOut" />
+  </XYChart>
+);
+
 export const Basic = {
   name: "Basic Plot",
   render: AreaTemplateWithControls,
@@ -183,8 +212,10 @@ export const Color = {
   },
 };
 
-export const Stream = {
-  name: "Stream Graph",
+// Not a Stream Graph - this fills the band between two y-series with a single Area plot. It used
+// to be mislabelled "Stream Graph"; the real thing is below, under `StackedAreas`
+export const RangeArea = {
+  name: "Range Area",
   render: AreaTemplate,
   args: {
     ...Basic.args,
@@ -276,6 +307,21 @@ export const StackedAreas = {
       expect(tooltip).toBeDefined();
     },
   ),
+};
+
+export const StreamGraph = {
+  name: "Stream Graph",
+  render: StreamGraphTemplate,
+  args: {
+    useCanvas: false,
+    width: 800,
+    height: 500,
+    animationDuration: 250,
+    leftMargin: 60,
+    rightMargin: 40,
+    topMargin: 20,
+    bottomMargin: 40,
+  },
 };
 
 export const StackedAreasWithBrush = {

--- a/packages/react/src/lib/components/Plots/Area/Areas.tsx
+++ b/packages/react/src/lib/components/Plots/Area/Areas.tsx
@@ -6,12 +6,26 @@ import { useSelector } from "react-redux";
 
 import { Area } from "./Area";
 import { StackedArea } from "./StackedArea";
+import { IStackOffset, IStackOrder } from "./StackedArea/StackedAreaBase";
 
 export interface IAreasProps extends IPlotsProps {
     /**
      * Should the area plots be stacked based on the x-value?
      */
     stacked?: boolean;
+
+    /**
+     * How the stack's layers should be offset from the baseline. Only applies when `stacked` is
+     * true - e.g. `offset="wiggle"` produces a streamgraph
+     * @default "none"
+     */
+    offset?: IStackOffset;
+
+    /**
+     * The order in which the stack's layers should be arranged. Only applies when `stacked` is true
+     * @default "none"
+     */
+    order?: IStackOrder;
 }
 
 /**
@@ -19,12 +33,12 @@ export interface IAreasProps extends IPlotsProps {
  * @param  props       The set of React properties
  * @return             The Area plot component
  */
-export function Areas({ ys, colors, stacked = false, ...props }: IAreasProps) {
+export function Areas({ ys, colors, stacked = false, offset, order, ...props }: IAreasProps) {
     const theme = useSelector((s: IState) => chartSelectors.theme(s));
     const palette = colors || theme.series.colors;
 
     if (stacked) {
-        return <StackedArea ys={ys} colors={palette} {...props} />;
+        return <StackedArea ys={ys} colors={palette} offset={offset} order={order} {...props} />;
     }
 
     return (

--- a/packages/react/src/lib/components/Plots/Area/StackedArea/StackedArea.unit.tsx
+++ b/packages/react/src/lib/components/Plots/Area/StackedArea/StackedArea.unit.tsx
@@ -38,6 +38,42 @@ describe("StackedArea", () => {
             expect(asFragment()).toMatchSnapshot();
         });
 
+        it("should render correctly with a wiggle offset and insideOut order", async () => {
+            const { asFragment } = await renderChart({
+                children: <StackedArea x="x" ys={["y", "y2"]} offset="wiggle" order="insideOut" />,
+                data,
+                scales,
+            });
+
+            await wait(200);
+
+            expect(asFragment()).toMatchSnapshot();
+        });
+
+        it("should offset the stack's baseline differently to the default zero-baseline stack", async () => {
+            const defaultRender = await renderChart({
+                children: <StackedArea x="x" ys={["y", "y2"]} />,
+                data,
+                scales,
+            });
+            await wait(200);
+            const defaultPaths = Array.from(defaultRender.container.querySelectorAll("path")).map((path) =>
+                path.getAttribute("d"),
+            );
+
+            const wiggleRender = await renderChart({
+                children: <StackedArea x="x" ys={["y", "y2"]} offset="wiggle" />,
+                data,
+                scales,
+            });
+            await wait(200);
+            const wigglePaths = Array.from(wiggleRender.container.querySelectorAll("path")).map((path) =>
+                path.getAttribute("d"),
+            );
+
+            expect(wigglePaths).not.toEqual(defaultPaths);
+        });
+
         describe("should skip rendering if", () => {
             it("there is no x scale avaliable", async () => {
                 const { asFragment } = await renderChart({

--- a/packages/react/src/lib/components/Plots/Area/StackedArea/StackedAreaBase.tsx
+++ b/packages/react/src/lib/components/Plots/Area/StackedArea/StackedAreaBase.tsx
@@ -11,6 +11,21 @@ import { useDatumFocus } from "./useDatumFocus";
 import { useMultiPathCreator } from "./useMultiPathCreator";
 import { useTooltip } from "./useTooltip";
 
+/**
+ * How the layers are positioned relative to one another. `none` stacks from a zero baseline
+ * (the default). `wiggle` and `silhouette` both float the baseline to minimize wiggle - `wiggle`
+ * is the standard choice for a streamgraph. `expand` normalizes every layer to a 0-1 range so the
+ * stack always fills the full height, useful for showing relative proportions over time
+ */
+export type IStackOffset = "none" | "wiggle" | "silhouette" | "expand";
+
+/**
+ * The order in which layers are stacked. `insideOut` (largest layers innermost, by inside-out
+ * appearance) is the standard pairing with a `wiggle` offset for a streamgraph, since it further
+ * reduces wiggle. `none` keeps the order `ys` was provided in
+ */
+export type IStackOrder = "none" | "ascending" | "descending" | "insideOut" | "reverse";
+
 export interface IStackedAreaBaseProps extends Omit<IEventPlotProps, "y"> {
     /**
      * The set of y fields to use to access the data for each plot
@@ -21,7 +36,34 @@ export interface IStackedAreaBaseProps extends Omit<IEventPlotProps, "y"> {
      * The set of colors to use for the different plot
      */
     colors?: Array<IColor>;
+
+    /**
+     * How the stack's layers should be offset from the baseline
+     * @default "none"
+     */
+    offset?: IStackOffset;
+
+    /**
+     * The order in which the stack's layers should be arranged
+     * @default "none"
+     */
+    order?: IStackOrder;
 }
+
+const STACK_OFFSETS: Record<IStackOffset, (typeof d3)["stackOffsetNone"]> = {
+    none: d3.stackOffsetNone,
+    wiggle: d3.stackOffsetWiggle,
+    silhouette: d3.stackOffsetSilhouette,
+    expand: d3.stackOffsetExpand,
+};
+
+const STACK_ORDERS: Record<IStackOrder, (typeof d3)["stackOrderNone"]> = {
+    none: d3.stackOrderNone,
+    ascending: d3.stackOrderAscending,
+    descending: d3.stackOrderDescending,
+    insideOut: d3.stackOrderInsideOut,
+    reverse: d3.stackOrderReverse,
+};
 
 /**
  * Represents a stacked Area Plot on an SVG Element
@@ -32,6 +74,8 @@ export function StackedAreaBase({
     x,
     ys,
     colors,
+    offset = "none",
+    order = "none",
     scaleMode = "plot",
     showInLegend = true,
     interactive = true,
@@ -67,7 +111,11 @@ export function StackedAreaBase({
         ensureNoScaleOverflow(yScale, sortedData, ys, "StackedSVGArea");
 
         // @ts-ignore: TODO: Not sure how to fix this
-        const stackedData = d3.stack().keys(ys)(sortedData);
+        const stackedData = d3
+            .stack()
+            .keys(ys)
+            .offset(STACK_OFFSETS[offset])
+            .order(STACK_ORDERS[order])(sortedData);
         const colorScale = d3.scaleOrdinal().domain(ys).range(colors);
 
         // Handle Canvas rendering
@@ -119,7 +167,7 @@ export function StackedAreaBase({
                 const current = areaShape(d);
                 return interpolateMultiPath(previous, current);
             });
-    }, [x, ys, sortedData, xScale, yScale, layer, animationDuration, theme.series.opacity]);
+    }, [x, ys, offset, order, sortedData, xScale, yScale, layer, animationDuration, theme.series.opacity]);
 
     // If possible respond to global mouse events for tooltips etc
     useDatumFocus({ interactive, x, ys, xScale, yScale, data: sortedData, colors });

--- a/packages/react/src/lib/components/Plots/Area/StackedArea/__snapshots__/StackedArea.unit.tsx.snap
+++ b/packages/react/src/lib/components/Plots/Area/StackedArea/__snapshots__/StackedArea.unit.tsx.snap
@@ -22,6 +22,28 @@ exports[`StackedArea using SVG should render correctly 1`] = `
 </DocumentFragment>
 `;
 
+exports[`StackedArea using SVG should render correctly with a wiggle offset and insideOut order 1`] = `
+<DocumentFragment>
+  <svg>
+    <g
+      class="g-plot stacked-area"
+      clip-path="url(#clip-path-test)"
+    >
+      <path
+        class="area"
+        d="M0,100L20,99.167L40,98.106L40,131.439L20,115.833L0,100Z                                                                                                            "
+        style="fill: #99c1dc; stroke: rgb(107, 135, 154); opacity: 0.7; pointer-events: none;"
+      />
+      <path
+        class="area"
+        d="M0,76.667L20,69.167L40,58.106L40,98.106L20,99.167L0,100Z                                                                                                              "
+        style="fill: #fc998e; stroke: rgb(176, 107, 99); opacity: 0.7; pointer-events: none;"
+      />
+    </g>
+  </svg>
+</DocumentFragment>
+`;
+
 exports[`StackedArea using SVG should skip rendering if there is no x scale avaliable 1`] = `
 <DocumentFragment>
   <svg>

--- a/packages/react/src/lib/components/Plots/Area/StackedArea/index.ts
+++ b/packages/react/src/lib/components/Plots/Area/StackedArea/index.ts
@@ -1,1 +1,2 @@
 export * from "./StackedArea";
+export * from "./StackedAreaBase";


### PR DESCRIPTION
## Summary

The Storybook "Stream Graph" story under `<Area>` didn't actually render a streamgraph - it rendered a plain `<Area>` with a `y2` band (sin/cos), which just *looks* wavy. It's not multiple stacked series with a floating baseline at all. On top of that, `<StackedArea>` always stacked with d3's default zero baseline (`stackOffsetNone`/`stackOrderNone`) with no way to override it, so a real streamgraph couldn't be built with the public API either. There's also an orphaned `stream_data.js` (1,500 lines) in `packages/react/src/data` that nothing imported - it looks like a real streamgraph example existed at some point (see #14) and was pulled, leaving the mislabelled story and dead data file behind.

This PR:

- Adds `offset` (`"none" | "wiggle" | "silhouette" | "expand"`) and `order` (`"none" | "ascending" | "descending" | "insideOut" | "reverse"`) props to `<StackedArea>` and `<Areas stacked>`, both defaulting to the previous behaviour (`"none"`/`"none"`) - a purely additive, non-breaking change.
- Relabels the old `<Area>` "Stream Graph" story to "Range Area", which is what it actually demonstrates (filling the band between two y-series with a single `<Area>`).
- Adds a real "Stream Graph" story under `<Areas>`, using `offset="wiggle" order="insideOut"` over the previously-unused `stream_data.js` dataset.
- Updates `Area.mdx` docs to match (corrects the `y2` prop description, documents the new `offset`/`order` props, and adds a Stream Graph section with a note on why the y-scale needs an explicit `domain` when using `offset="wiggle"`, since the `aggregate` zero-to-sum domain doesn't fit a floating baseline).
- Adds a changeset (`@chart-io/react`: minor).

## Test plan

- [x] `tsc --noEmit` passes with no errors across `packages/react`
- [x] Full `packages/react` jest suite passes (341/341, including a new unit test asserting `offset="wiggle"` produces different path geometry than the default zero-baseline stack, plus a snapshot test for `offset="wiggle" order="insideOut"`)
- [x] Existing `StackedArea`/`Areas` snapshots are byte-identical (confirms the new props don't change default behaviour)
- [ ] Visual check of the new "Stream Graph" and relabelled "Range Area" stories in Storybook (not run in this environment - worth a look before merging)

---
_Generated by [Claude Code](https://claude.ai/code/session_0184WymUJHEgg1KSv1ZfGRDR)_