### PR TITLE
Fix Canvas hover highlight on Column/Bar plots

### DIFF
--- a/.changeset/column-bar-canvas-hover-highlight.md
+++ b/.changeset/column-bar-canvas-hover-highlight.md
@@ -1,0 +1,5 @@
+---
+"@chart-io/react": patch
+---
+
+Fixed the hovered item not being highlighted on Canvas-rendered `<Column useCanvas>`, `<GroupedColumn useCanvas>`, `<StackedColumn useCanvas>`, `<Bar useCanvas>`, `<GroupedBar useCanvas>` and `<StackedBar useCanvas>` charts. Hovering updated the item's opacity on its underlying (detached) DOM node as before, but nothing repainted the visible `<canvas>` bitmap to reflect it, so the highlight silently never appeared - unlike SVG, where the browser repaints the style change on its own. This is the same fix already applied to `<Donut>`/`<Pie>`/`<StackedDonut>` in #245.

--- a/packages/react/src/lib/components/Plots/Bar/Bar/Bar.unit.tsx
+++ b/packages/react/src/lib/components/Plots/Bar/Bar/Bar.unit.tsx
@@ -266,6 +266,48 @@ describe("Bar", () => {
                     pageY: 10,
                 });
             });
+
+            it("highlights the hovered bar on the canvas bitmap, and un-highlights it on exit", async () => {
+                const onMouseOver = jest.fn();
+                const onMouseOut = jest.fn();
+
+                const { container } = await renderChart({
+                    children: (
+                        <VirtualCanvas>
+                            <Bar x="x" y="y" onMouseOver={onMouseOver} onMouseOut={onMouseOut} useCanvas={true} />
+                        </VirtualCanvas>
+                    ),
+                    data,
+                    scales,
+                });
+
+                await wait(VIRTUAL_CANVAS_DEBOUNCE * 2);
+
+                const canvas = container.querySelector(".canvas") as HTMLCanvasElement;
+                const context = canvas.getContext("2d");
+                const getAlpha = () => context.getImageData(10, 10, 1, 1).data[3];
+
+                const initialAlpha = getAlpha();
+
+                await testMouseOver(container, ".virtual-canvas", onMouseOver, expectedDatum, {
+                    bubbles: true,
+                    pageX: 10,
+                    pageY: 10,
+                });
+
+                expect(getAlpha()).not.toBe(initialAlpha);
+
+                await testMouseExit(
+                    container,
+                    ".virtual-canvas",
+                    onMouseOut,
+                    expectedDatum,
+                    { pageX: 10, pageY: 10 },
+                    { pageX: 95, pageY: 95 },
+                );
+
+                expect(getAlpha()).toBe(initialAlpha);
+            });
         });
     });
 });

--- a/packages/react/src/lib/components/Plots/Bar/Bar/BarBase.tsx
+++ b/packages/react/src/lib/components/Plots/Bar/Bar/BarBase.tsx
@@ -48,7 +48,7 @@ export function BarBase({
 
     useLegendItem(x, "square", showInLegend, fillColor);
     const onTooltip = useTooltip({ y });
-    const onFocus = useFocused({ yScale, theme, grouped: false });
+    const onFocus = useFocused({ yScale, theme, grouped: false, canvasRedraw: { canvas, width, height, layer } });
 
     useRender(() => {
         const { bandwidth, offset } = getBandwidthAndOffset(yScale, y, data);

--- a/packages/react/src/lib/components/Plots/Bar/GroupedBar/GroupedBarBase.tsx
+++ b/packages/react/src/lib/components/Plots/Bar/GroupedBar/GroupedBarBase.tsx
@@ -56,7 +56,7 @@ export function GroupedBarBase({
     const animationDuration = useSelector((s: IState) => chartSelectors.animationDuration(s));
 
     const onTooltip = useTooltip({ y });
-    const onFocus = useFocused({ yScale, theme, grouped: true });
+    const onFocus = useFocused({ yScale, theme, grouped: true, canvasRedraw: { canvas, width, height, layer } });
 
     useLegendItems(xs, "square", showInLegend, colors);
 

--- a/packages/react/src/lib/components/Plots/Bar/StackedBar/StackedBarBase.tsx
+++ b/packages/react/src/lib/components/Plots/Bar/StackedBar/StackedBarBase.tsx
@@ -65,7 +65,7 @@ export function StackedBarBase({
     const animationDuration = useSelector((s: IState) => chartSelectors.animationDuration(s));
 
     const onTooltip = useTooltip({ y });
-    const onFocus = useFocused({ yScale, theme, grouped: false });
+    const onFocus = useFocused({ yScale, theme, grouped: false, canvasRedraw: { canvas, width, height, layer } });
 
     useLegendItems(xs, "square", showInLegend, colors);
 

--- a/packages/react/src/lib/components/Plots/Bar/useFocused.ts
+++ b/packages/react/src/lib/components/Plots/Bar/useFocused.ts
@@ -4,6 +4,9 @@ import type { IColor, IDispatch, IFocused, IScale, ITheme } from "@chart-io/core
 import { useEffect, useState } from "react";
 import { useStore } from "react-redux";
 
+import type { ICanvasRedraw } from "../useFocused";
+import { redrawCanvas } from "../renderCanvas";
+
 export interface IBarFocusProps {
     /**
      * The redux store dispatch function
@@ -25,14 +28,20 @@ export interface IBarFocusProps {
      * True if the columns are grouped
      */
     grouped?: boolean;
+    /**
+     * The details needed to redraw the Canvas, if this plot is using one
+     */
+    canvasRedraw?: ICanvasRedraw;
 }
 
 /**
  * Helper function to manage markers & droplines for a selected datum on the Bar plot
  * @return              A function to set the focused datum
  */
-function focus({ dispatch, focused, theme, yScale, grouped = false }: IBarFocusProps) {
+function focus({ dispatch, focused, theme, yScale, grouped = false, canvasRedraw }: IBarFocusProps) {
     if (!focused) return;
+
+    const { canvas, width: canvasWidth, height: canvasHeight, layer } = canvasRedraw ?? {};
 
     // Get the appropriate attributes
     const { element } = focused;
@@ -45,6 +54,7 @@ function focus({ dispatch, focused, theme, yScale, grouped = false }: IBarFocusP
         grouped === false ? 0 : getXYFromTransform(d3.select(selection.node().parentNode).attr("transform")).y;
 
     selection.style("opacity", theme.series.selectedOpacity);
+    redrawCanvas(canvas, canvasWidth, canvasHeight, layer);
 
     const verticalDropline = {
         isVertical: true,
@@ -59,25 +69,27 @@ function focus({ dispatch, focused, theme, yScale, grouped = false }: IBarFocusP
 
     return () => {
         selection.style("opacity", theme.series.opacity);
+        redrawCanvas(canvas, canvasWidth, canvasHeight, layer);
         dispatch(eventActions.removeDropline(verticalDropline));
     };
 }
 
 /**
  * Handles the user interacting with a DataPoint on the Bar chart and the need to display a tooltip
- * @param  dispatch     The redux store dispatch function
- * @param  yScale       The d3 scale for the x-axis
- * @param  theme        The theme for the chart
- * @param  grouped      Whether the data on the chart is grouped
- * @return              A function to set the focused datum
+ * @param  yScale         The d3 scale for the x-axis
+ * @param  theme          The theme for the chart
+ * @param  grouped        Whether the data on the chart is grouped
+ * @param  canvasRedraw   The details needed to redraw the Canvas, if this plot is using one
+ * @return                A function to set the focused datum
  */
-export const useFocused = ({ yScale, theme, grouped }: Omit<IBarFocusProps, "dispatch" | "focused">) => {
+export const useFocused = ({ yScale, theme, grouped, canvasRedraw }: Omit<IBarFocusProps, "dispatch" | "focused">) => {
     const { dispatch } = useStore();
     const [focused, setFocused] = useState(null);
+    const { canvas, width: canvasWidth, height: canvasHeight, layer } = canvasRedraw ?? {};
 
     useEffect(() => {
-        return focus({ dispatch, yScale, focused, theme, grouped });
-    }, [dispatch, focused, yScale, theme.series.selectedOpacity]);
+        return focus({ dispatch, yScale, focused, theme, grouped, canvasRedraw });
+    }, [dispatch, focused, yScale, theme.series.selectedOpacity, canvas, canvasWidth, canvasHeight, layer]);
 
     return setFocused;
 };

--- a/packages/react/src/lib/components/Plots/Column/Column/Column.unit.tsx
+++ b/packages/react/src/lib/components/Plots/Column/Column/Column.unit.tsx
@@ -266,6 +266,48 @@ describe("Column", () => {
                     pageY: 90,
                 });
             });
+
+            it("highlights the hovered column on the canvas bitmap, and un-highlights it on exit", async () => {
+                const onMouseOver = jest.fn();
+                const onMouseOut = jest.fn();
+
+                const { container } = await renderChart({
+                    children: (
+                        <VirtualCanvas>
+                            <Column x="x" y="y" onMouseOver={onMouseOver} onMouseOut={onMouseOut} useCanvas={true} />
+                        </VirtualCanvas>
+                    ),
+                    data,
+                    scales,
+                });
+
+                await wait(VIRTUAL_CANVAS_DEBOUNCE * 2);
+
+                const canvas = container.querySelector(".canvas") as HTMLCanvasElement;
+                const context = canvas.getContext("2d");
+                const getAlpha = () => context.getImageData(25, 90, 1, 1).data[3];
+
+                const initialAlpha = getAlpha();
+
+                await testMouseOver(container, ".virtual-canvas", onMouseOver, expectedDatum, {
+                    bubbles: true,
+                    pageX: 25,
+                    pageY: 90,
+                });
+
+                expect(getAlpha()).not.toBe(initialAlpha);
+
+                await testMouseExit(
+                    container,
+                    ".virtual-canvas",
+                    onMouseOut,
+                    expectedDatum,
+                    { pageX: 25, pageY: 90 },
+                    { pageX: 195, pageY: 95 },
+                );
+
+                expect(getAlpha()).toBe(initialAlpha);
+            });
         });
     });
 });

--- a/packages/react/src/lib/components/Plots/Column/Column/ColumnBase.tsx
+++ b/packages/react/src/lib/components/Plots/Column/Column/ColumnBase.tsx
@@ -48,7 +48,7 @@ export function ColumnBase({
 
     useLegendItem(y, "square", showInLegend, fillColor);
     const onTooltip = useTooltip({ x });
-    const onFocus = useFocused({ xScale, theme, grouped: false });
+    const onFocus = useFocused({ xScale, theme, grouped: false, canvasRedraw: { canvas, width, height, layer } });
 
     useRender(() => {
         const { bandwidth, offset } = getBandwidthAndOffset(xScale, x, data);

--- a/packages/react/src/lib/components/Plots/Column/GroupedColumn/GroupedColumnBase.tsx
+++ b/packages/react/src/lib/components/Plots/Column/GroupedColumn/GroupedColumnBase.tsx
@@ -53,7 +53,7 @@ export function GroupedColumnBase({
     const animationDuration = useSelector((s: IState) => chartSelectors.animationDuration(s));
 
     const onTooltip = useTooltip({ x });
-    const onFocus = useFocused({ xScale, theme, grouped: true });
+    const onFocus = useFocused({ xScale, theme, grouped: true, canvasRedraw: { canvas, width, height, layer } });
 
     useLegendItems(ys, "square", showInLegend, colors);
 

--- a/packages/react/src/lib/components/Plots/Column/StackedColumn/StackedColumnBase.tsx
+++ b/packages/react/src/lib/components/Plots/Column/StackedColumn/StackedColumnBase.tsx
@@ -62,7 +62,7 @@ export function StackedColumnBase({
     const animationDuration = useSelector((s: IState) => chartSelectors.animationDuration(s));
 
     const onTooltip = useTooltip({ x });
-    const onFocus = useFocused({ xScale, theme, grouped: false });
+    const onFocus = useFocused({ xScale, theme, grouped: false, canvasRedraw: { canvas, width, height, layer } });
 
     useLegendItems(ys, "square", showInLegend, colors);
 

--- a/packages/react/src/lib/components/Plots/Column/useFocused.ts
+++ b/packages/react/src/lib/components/Plots/Column/useFocused.ts
@@ -4,6 +4,9 @@ import type { IColor, IDispatch, IFocused, IScale, ITheme } from "@chart-io/core
 import { useEffect, useState } from "react";
 import { useStore } from "react-redux";
 
+import type { ICanvasRedraw } from "../useFocused";
+import { redrawCanvas } from "../renderCanvas";
+
 export interface IColumnFocusProps {
     /**
      * The redux store dispatch function
@@ -25,14 +28,20 @@ export interface IColumnFocusProps {
      * True if the columns are grouped
      */
     grouped?: boolean;
+    /**
+     * The details needed to redraw the Canvas, if this plot is using one
+     */
+    canvasRedraw?: ICanvasRedraw;
 }
 
 /**
  * Helper function to manage markers & droplines for a selected datum on the Column plot
  * @return              A function to set the focused datum
  */
-function focus({ dispatch, focused, theme, xScale, grouped = false }: IColumnFocusProps) {
+function focus({ dispatch, focused, theme, xScale, grouped = false, canvasRedraw }: IColumnFocusProps) {
     if (!focused) return;
+
+    const { canvas, width, height, layer } = canvasRedraw ?? {};
 
     // Get the appropriate attributes
     const { element } = focused;
@@ -44,6 +53,7 @@ function focus({ dispatch, focused, theme, xScale, grouped = false }: IColumnFoc
         grouped === false ? 0 : getXYFromTransform(d3.select(selection.node().parentNode).attr("transform")).x;
 
     selection.style("opacity", theme.series.selectedOpacity);
+    redrawCanvas(canvas, width, height, layer);
 
     const horizontalDropline = {
         isHorizontal: true,
@@ -58,25 +68,32 @@ function focus({ dispatch, focused, theme, xScale, grouped = false }: IColumnFoc
 
     return () => {
         selection.style("opacity", theme.series.opacity);
+        redrawCanvas(canvas, width, height, layer);
         dispatch(eventActions.removeDropline(horizontalDropline));
     };
 }
 
 /**
  * Handles the user interacting with a DataPoint on the Column chart and the need to display a tooltip
- * @param  dispatch     The redux store dispatch function
- * @param  xScale       The d3 scale for the x-axis
- * @param  theme        The theme for the chart
- * @param  grouped      Whether the data on the chart is grouped
- * @return              A function to set the focused datum
+ * @param  xScale         The d3 scale for the x-axis
+ * @param  theme          The theme for the chart
+ * @param  grouped        Whether the data on the chart is grouped
+ * @param  canvasRedraw   The details needed to redraw the Canvas, if this plot is using one
+ * @return                A function to set the focused datum
  */
-export const useFocused = ({ xScale, theme, grouped }: Omit<IColumnFocusProps, "dispatch" | "focused">) => {
+export const useFocused = ({
+    xScale,
+    theme,
+    grouped,
+    canvasRedraw,
+}: Omit<IColumnFocusProps, "dispatch" | "focused">) => {
     const { dispatch } = useStore();
     const [focused, setFocused] = useState(null);
+    const { canvas, width, height, layer } = canvasRedraw ?? {};
 
     useEffect(() => {
-        return focus({ dispatch, xScale, focused, theme, grouped });
-    }, [dispatch, focused, xScale, theme.series.selectedOpacity]);
+        return focus({ dispatch, xScale, focused, theme, grouped, canvasRedraw });
+    }, [dispatch, focused, xScale, theme.series.selectedOpacity, canvas, width, height, layer]);
 
     return setFocused;
 };


### PR DESCRIPTION
## Summary

Follow-up to #245's fix for Canvas hover highlighting. That PR fixed `Donut`/`Pie`/`StackedDonut`, and left a review comment asking whether the same gap existed elsewhere ([discussion](https://github.com/IPWright83/chart-io/pull/245#discussion_r3789636349)). It does:

- **`Column`/`Bar` (and their `Grouped`/`Stacked` variants)**: their shared `useFocused` hooks set `opacity` directly on the hovered element's underlying (detached) DOM node, same as `Donut` did before #245 - which works for SVG (the browser repaints the style change) but silently does nothing for Canvas (nothing repaints the bitmap). Wired in the `redrawCanvas()` helper from #245 so hovering a Column/Bar segment on `useCanvas` now actually highlights it, and un-highlights it again on mouse-out.
- **`Scatter`**: checked, but not affected - its `useFocused` only adds/removes markers and droplines, it never touches an element's opacity, so there's no equivalent bug to fix there.

## Test plan

- [x] `pnpm --filter @chart-io/core build && pnpm --filter @chart-io/react run types` - clean
- [x] `pnpm test` - all suites pass (added new tests asserting the canvas bitmap's pixel alpha changes on hover and reverts on exit for `Column` and `Bar`; verified the new tests fail without the `redrawCanvas()` call, confirming they catch the regression)
- [x] `eslint` on all touched files - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2Z2PguXVLMYgcqcA5RpHB


---
_Generated by [Claude Code](https://claude.ai/code/session_01U2Z2PguXVLMYgcqcA5RpHB)_