### PR TITLE
Add ZAxis a nested-circle legend for Scatter's z (size) encoding

### DIFF
--- a/.changeset/z-axis-bubble-legend.md
+++ b/.changeset/z-axis-bubble-legend.md
@@ -1,0 +1,5 @@
+---
+"@chart-io/react": minor
+---
+
+Added `<ZAxis>`, a legend for the size (`z`) encoding of a `<Scatter z>`/`<Scatters z>` bubble chart. It draws a set of circles nested inside one another sharing a baseline, each labelled with the value it represents via a leader line - in the style of a New York Times bubble-size legend. `<ZAxis>` sets up the same scale `<Scatter z>`/`<Scatters z>` read their radius from (like `<XAxis>`/`<YAxis>` do for `x`/`y`), so the legend's circles are always drawn at the same size as the series' points they describe. `horizontalPosition`/`verticalPosition` anchor it to a corner of the plot, and `ticks`/`tickValues`/`tickFormat` control which values get a circle and how they're labelled.

--- a/packages/react/src/lib/components/Axis/ZAxis/ZAxis.tsx
+++ b/packages/react/src/lib/components/Axis/ZAxis/ZAxis.tsx
@@ -1,0 +1,267 @@
+import { chartSelectors, d3, IState } from "@chart-io/core";
+import type { IScaleType, IValue } from "@chart-io/core";
+
+import React, { useEffect, useRef } from "react";
+import { useSelector } from "react-redux";
+
+import { useArray } from "../../../hooks";
+import { ZScale } from "../../Scale";
+
+export interface IZAxisProps {
+    /**
+     * The key of the field used to build the z (size) scale - pass the same field to a
+     * `<Scatter z>`/`<Scatters z>` so its circles are sized against this legend
+     */
+    fields: string | Array<string>;
+    /**
+     * (Optional) An override of the domain to use with the d3 scale
+     */
+    domain?: IValue[];
+    /**
+     * (Optional) An override of the type of d3 scale to use
+     */
+    scaleType?: IScaleType;
+    /**
+     * (Optional) An override of the pixel radius range the scale maps values onto. Keep this in
+     * sync with any other `<ZAxis>`/`<ZScale>` sharing the field, so the legend's circles are drawn
+     * at the same size as the series' circles they describe
+     * @default [5, 25]
+     */
+    range?: number[];
+    /**
+     * The number of concentric circles to draw, each a representative value picked from the scale's
+     * domain (e.g. a low/mid/high spread). Ignored when `tickValues` is provided
+     * @default 3
+     */
+    ticks?: number;
+    /**
+     * (Optional) Explicit values to draw a circle for, instead of letting `ticks` pick them
+     * automatically
+     */
+    tickValues?: IValue[];
+    /**
+     * A function to format each circle's value label
+     * @default (value) => `${value}`
+     */
+    tickFormat?: (value: IValue) => string;
+    /**
+     * Which side of the plot to anchor the legend to
+     * @default "RIGHT"
+     */
+    horizontalPosition?: "LEFT" | "RIGHT" | "CENTER";
+    /**
+     * Which edge of the plot the circles share a baseline with. Circles are nested inside one
+     * another growing away from this edge, largest on the outside, in the style of a New York
+     * Times bubble-size legend
+     * @default "BOTTOM"
+     */
+    verticalPosition?: "TOP" | "BOTTOM";
+    /**
+     * The gap, in pixels, to leave between the legend and the edges of the plot area it's anchored to
+     * @default 20
+     */
+    padding?: number;
+}
+
+/**
+ * Represents a ZAxis, drawing a legend of concentric, nested circles - one per representative
+ * value - each labelled via a leader line. Used to explain the size encoding of a `<Scatter z>`/
+ * `<Scatters z>`'s circles, in the style of a New York Times bubble-size legend
+ * @return The ZAxis component
+ */
+export function ZAxis({
+    fields,
+    domain,
+    scaleType,
+    range = [5, 25],
+    ticks = 3,
+    tickValues,
+    tickFormat,
+    horizontalPosition = "RIGHT",
+    verticalPosition = "BOTTOM",
+    padding = 20,
+}: IZAxisProps) {
+    const fieldsArray = useArray(fields);
+    const field = fieldsArray[0];
+
+    return (
+        <React.Fragment>
+            <ZAxisLegend
+                field={field}
+                ticks={ticks}
+                tickValues={tickValues}
+                tickFormat={tickFormat}
+                horizontalPosition={horizontalPosition}
+                verticalPosition={verticalPosition}
+                padding={padding}
+            />
+            <ZScale fields={fieldsArray} scaleType={scaleType} range={range} domain={domain} />
+        </React.Fragment>
+    );
+}
+
+const defaultTickFormat = (value: IValue) => `${value}`;
+const LABEL_PADDING = 6;
+const LEADER_LENGTH = 16;
+
+/**
+ * Renders the nested circles, leader lines and labels for a ZAxis. Kept separate from `<ZAxis>`
+ * itself since this subscribes to the resolved scale (and so re-renders whenever it's set), whereas
+ * the sibling `<ZScale>` that sets it must not, to avoid the two re-triggering one another
+ * @return The visual part of the ZAxis
+ */
+function ZAxisLegend({
+    field,
+    ticks,
+    tickValues,
+    tickFormat = defaultTickFormat,
+    horizontalPosition,
+    verticalPosition,
+    padding,
+}: {
+    field: string;
+    ticks: number;
+    tickValues: IValue[] | undefined;
+    tickFormat: ((value: IValue) => string) | undefined;
+    horizontalPosition: "LEFT" | "RIGHT" | "CENTER";
+    verticalPosition: "TOP" | "BOTTOM";
+    padding: number;
+}) {
+    const left = useSelector((s: IState) => chartSelectors.dimensions.plot.left(s));
+    const right = useSelector((s: IState) => chartSelectors.dimensions.plot.right(s));
+    const top = useSelector((s: IState) => chartSelectors.dimensions.plot.top(s));
+    const bottom = useSelector((s: IState) => chartSelectors.dimensions.plot.bottom(s));
+    const theme = useSelector((s: IState) => chartSelectors.theme(s));
+    const animationDuration = useSelector((s: IState) => chartSelectors.animationDuration(s));
+    const scale = useSelector((s: IState) => chartSelectors.scales.getScale(s, field, "plot"));
+
+    const layer = useRef(null);
+
+    useEffect(() => {
+        if (!layer.current || !scale) {
+            return;
+        }
+
+        // The intersected call signature on IScale doesn't resolve cleanly against a plain IValue argument
+        const scaleOf = scale as unknown as (value: IValue) => number;
+
+        // A continuous scale (e.g. linear/power) has `ticks()`; a categorical scale doesn't, so
+        // fall back to its raw domain values
+        const hasTicks = typeof (scale as unknown as { ticks?: unknown }).ticks === "function";
+        const rawValues = (
+            tickValues ??
+            (hasTicks ? (scale as unknown as { ticks: (count: number) => IValue[] }).ticks(ticks) : scale.domain())
+        ) as IValue[];
+
+        // Largest first, so its circle is entered/exited first and the smaller circles nest visibly
+        // on top of it
+        const values = [...rawValues].sort((a, b) => scaleOf(b) - scaleOf(a));
+
+        const maxRadius = values.reduce<number>((max, d) => Math.max(max, scaleOf(d)), 0);
+        const labelDirection = horizontalPosition === "LEFT" ? -1 : 1;
+
+        const cx =
+            horizontalPosition === "LEFT"
+                ? left + padding + maxRadius
+                : horizontalPosition === "CENTER"
+                  ? (left + right) / 2
+                  : right - padding - maxRadius;
+        const baselineY = verticalPosition === "TOP" ? top + padding : bottom - padding;
+        const leaderEndX = cx + labelDirection * (maxRadius + LEADER_LENGTH);
+
+        // Where a circle's center sits, offset from the shared baseline by its own radius so every
+        // circle's edge touches the same baseline
+        const cyOf = (d: IValue) => (verticalPosition === "TOP" ? baselineY + scaleOf(d) : baselineY - scaleOf(d));
+        // The circle's edge furthest from the baseline - the part that's uniquely visible above/below
+        // the circles nested inside it, and so where its leader line/label anchor
+        const edgeOf = (d: IValue) => (verticalPosition === "TOP" ? cyOf(d) + scaleOf(d) : cyOf(d) - scaleOf(d));
+
+        const join = d3
+            .select(layer.current)
+            .selectAll(".z-axis-tick")
+            .data(values, (d) => `${d}`);
+
+        join.exit().remove();
+
+        const enter = join.enter().append("g").attr("class", "z-axis-tick");
+        // Entering circles/leaders/labels start at their final position rather than the SVG
+        // attribute defaults - only pre-existing ticks moving to a new position should animate, not
+        // ones appearing for the first time
+        enter
+            .append("circle")
+            .attr("class", "z-axis-ring")
+            .attr("cx", cx)
+            .attr("cy", (d) => cyOf(d))
+            .attr("r", (d) => Math.max(0, scaleOf(d)));
+        enter
+            .append("line")
+            .attr("class", "z-axis-leader")
+            .attr("x1", cx)
+            .attr("y1", (d) => edgeOf(d))
+            .attr("x2", leaderEndX)
+            .attr("y2", (d) => edgeOf(d));
+        enter
+            .append("text")
+            .attr("class", "z-axis-label")
+            .attr("x", leaderEndX + labelDirection * LABEL_PADDING)
+            .attr("y", (d) => edgeOf(d));
+
+        const update = enter.merge(join as any);
+
+        update
+            .select<SVGCircleElement>("circle.z-axis-ring")
+            .style("fill", "none")
+            .style("stroke", theme.axis.stroke?.toString())
+            .style("stroke-opacity", theme.axis.strokeOpacity)
+            .style("stroke-width", theme.axis.strokeWidth)
+            .attr("cx", cx)
+            .transition()
+            .duration(animationDuration)
+            .attr("cy", (d) => cyOf(d))
+            .attr("r", (d) => Math.max(0, scaleOf(d)));
+
+        update
+            .select<SVGLineElement>("line.z-axis-leader")
+            .style("stroke", theme.axis.stroke?.toString())
+            .style("stroke-opacity", theme.axis.strokeOpacity)
+            .style("stroke-width", theme.axis.strokeWidth)
+            .style("stroke-dasharray", "2,2")
+            .attr("x1", cx)
+            .attr("x2", leaderEndX)
+            .transition()
+            .duration(animationDuration)
+            .attr("y1", (d) => edgeOf(d))
+            .attr("y2", (d) => edgeOf(d));
+
+        update
+            .select<SVGTextElement>("text.z-axis-label")
+            .text((d) => tickFormat(d))
+            .style("fill", theme.label.color?.toString())
+            .style("font-size", theme.label.fontSize)
+            .style("font-family", theme.label.fontFamily)
+            .style("user-select", "none")
+            .attr("text-anchor", labelDirection === 1 ? "start" : "end")
+            .attr("dominant-baseline", "middle")
+            .attr("x", leaderEndX + labelDirection * LABEL_PADDING)
+            .transition()
+            .duration(animationDuration)
+            .attr("y", (d) => edgeOf(d));
+    }, [
+        field,
+        scale,
+        left,
+        right,
+        top,
+        bottom,
+        theme,
+        animationDuration,
+        ticks,
+        tickValues,
+        tickFormat,
+        horizontalPosition,
+        verticalPosition,
+        padding,
+    ]);
+
+    return <g className="chart-io z-axis" ref={layer} style={{ pointerEvents: "none" }} />;
+}

--- a/packages/react/src/lib/components/Axis/ZAxis/ZAxis.unit.tsx
+++ b/packages/react/src/lib/components/Axis/ZAxis/ZAxis.unit.tsx
@@ -1,0 +1,71 @@
+import { d3, themes } from "@chart-io/core";
+
+import { Provider } from "react-redux";
+import React from "react";
+import { render } from "@testing-library/react";
+
+import { createMockStore, wait } from "../../../testUtils";
+
+import { ZAxis } from ".";
+
+describe("ZAxis", () => {
+    const width = 200;
+    const height = 200;
+
+    const store = createMockStore({
+        chart: {
+            theme: themes.light,
+            animationDuration: 0,
+            dimensions: { width, height },
+            data: [{ population: 10 }, { population: 50 }, { population: 100 }],
+            scales: {
+                population: {
+                    scale: d3.scaleLinear().domain([0, 100]).range([5, 25]),
+                    domain: [0, 100],
+                    range: [5, 25],
+                },
+            },
+        },
+    });
+
+    it("should render a nested circle, leader line and label per representative value", async () => {
+        const { asFragment } = render(
+            <Provider store={store}>
+                <svg>
+                    <ZAxis fields="population" ticks={3} />
+                </svg>
+            </Provider>,
+        );
+
+        // Wait for the entrance transition to settle so the snapshot deterministically captures
+        // the final circle/label position rather than a mid-animation frame
+        await wait();
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it("should render on the left, hanging from the top, when positioned there", async () => {
+        const { asFragment } = render(
+            <Provider store={store}>
+                <svg>
+                    <ZAxis fields="population" ticks={3} horizontalPosition="LEFT" verticalPosition="TOP" />
+                </svg>
+            </Provider>,
+        );
+
+        await wait();
+        expect(asFragment()).toMatchSnapshot();
+    });
+
+    it("should render a circle per explicit tickValues, ignoring ticks", async () => {
+        const { asFragment } = render(
+            <Provider store={store}>
+                <svg>
+                    <ZAxis fields="population" tickValues={[10, 100]} />
+                </svg>
+            </Provider>,
+        );
+
+        await wait();
+        expect(asFragment()).toMatchSnapshot();
+    });
+});

--- a/packages/react/src/lib/components/Axis/ZAxis/__snapshots__/ZAxis.unit.tsx.snap
+++ b/packages/react/src/lib/components/Axis/ZAxis/__snapshots__/ZAxis.unit.tsx.snap
@@ -1,0 +1,269 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ZAxis should render a circle per explicit tickValues, ignoring ticks 1`] = `
+<DocumentFragment>
+  <svg>
+    <g
+      class="chart-io z-axis"
+      style="pointer-events: none;"
+    >
+      <g
+        class="z-axis-tick"
+      >
+        <circle
+          class="z-axis-ring"
+          cx="155"
+          cy="155"
+          r="25"
+          style="fill: none; stroke: #333333; stroke-opacity: 0.8; stroke-width: 1;"
+        />
+        <line
+          class="z-axis-leader"
+          style="stroke: #333333; stroke-opacity: 0.8; stroke-width: 1; stroke-dasharray: 2,2;"
+          x1="155"
+          x2="196"
+          y1="130"
+          y2="130"
+        />
+        <text
+          class="z-axis-label"
+          dominant-baseline="middle"
+          style="fill: #333333; font-family: sans-serif; user-select: none;"
+          text-anchor="start"
+          x="202"
+          y="130"
+        >
+          100
+        </text>
+      </g>
+      <g
+        class="z-axis-tick"
+      >
+        <circle
+          class="z-axis-ring"
+          cx="155"
+          cy="173"
+          r="7"
+          style="fill: none; stroke: #333333; stroke-opacity: 0.8; stroke-width: 1;"
+        />
+        <line
+          class="z-axis-leader"
+          style="stroke: #333333; stroke-opacity: 0.8; stroke-width: 1; stroke-dasharray: 2,2;"
+          x1="155"
+          x2="196"
+          y1="166"
+          y2="166"
+        />
+        <text
+          class="z-axis-label"
+          dominant-baseline="middle"
+          style="fill: #333333; font-family: sans-serif; user-select: none;"
+          text-anchor="start"
+          x="202"
+          y="166"
+        >
+          10
+        </text>
+      </g>
+    </g>
+  </svg>
+</DocumentFragment>
+`;
+
+exports[`ZAxis should render a nested circle, leader line and label per representative value 1`] = `
+<DocumentFragment>
+  <svg>
+    <g
+      class="chart-io z-axis"
+      style="pointer-events: none;"
+    >
+      <g
+        class="z-axis-tick"
+      >
+        <circle
+          class="z-axis-ring"
+          cx="155"
+          cy="155"
+          r="25"
+          style="fill: none; stroke: #333333; stroke-opacity: 0.8; stroke-width: 1;"
+        />
+        <line
+          class="z-axis-leader"
+          style="stroke: #333333; stroke-opacity: 0.8; stroke-width: 1; stroke-dasharray: 2,2;"
+          x1="155"
+          x2="196"
+          y1="130"
+          y2="130"
+        />
+        <text
+          class="z-axis-label"
+          dominant-baseline="middle"
+          style="fill: #333333; font-family: sans-serif; user-select: none;"
+          text-anchor="start"
+          x="202"
+          y="130"
+        >
+          100
+        </text>
+      </g>
+      <g
+        class="z-axis-tick"
+      >
+        <circle
+          class="z-axis-ring"
+          cx="155"
+          cy="165"
+          r="15"
+          style="fill: none; stroke: #333333; stroke-opacity: 0.8; stroke-width: 1;"
+        />
+        <line
+          class="z-axis-leader"
+          style="stroke: #333333; stroke-opacity: 0.8; stroke-width: 1; stroke-dasharray: 2,2;"
+          x1="155"
+          x2="196"
+          y1="150"
+          y2="150"
+        />
+        <text
+          class="z-axis-label"
+          dominant-baseline="middle"
+          style="fill: #333333; font-family: sans-serif; user-select: none;"
+          text-anchor="start"
+          x="202"
+          y="150"
+        >
+          50
+        </text>
+      </g>
+      <g
+        class="z-axis-tick"
+      >
+        <circle
+          class="z-axis-ring"
+          cx="155"
+          cy="175"
+          r="5"
+          style="fill: none; stroke: #333333; stroke-opacity: 0.8; stroke-width: 1;"
+        />
+        <line
+          class="z-axis-leader"
+          style="stroke: #333333; stroke-opacity: 0.8; stroke-width: 1; stroke-dasharray: 2,2;"
+          x1="155"
+          x2="196"
+          y1="170"
+          y2="170"
+        />
+        <text
+          class="z-axis-label"
+          dominant-baseline="middle"
+          style="fill: #333333; font-family: sans-serif; user-select: none;"
+          text-anchor="start"
+          x="202"
+          y="170"
+        >
+          0
+        </text>
+      </g>
+    </g>
+  </svg>
+</DocumentFragment>
+`;
+
+exports[`ZAxis should render on the left, hanging from the top, when positioned there 1`] = `
+<DocumentFragment>
+  <svg>
+    <g
+      class="chart-io z-axis"
+      style="pointer-events: none;"
+    >
+      <g
+        class="z-axis-tick"
+      >
+        <circle
+          class="z-axis-ring"
+          cx="45"
+          cy="45"
+          r="25"
+          style="fill: none; stroke: #333333; stroke-opacity: 0.8; stroke-width: 1;"
+        />
+        <line
+          class="z-axis-leader"
+          style="stroke: #333333; stroke-opacity: 0.8; stroke-width: 1; stroke-dasharray: 2,2;"
+          x1="45"
+          x2="4"
+          y1="70"
+          y2="70"
+        />
+        <text
+          class="z-axis-label"
+          dominant-baseline="middle"
+          style="fill: #333333; font-family: sans-serif; user-select: none;"
+          text-anchor="end"
+          x="-2"
+          y="70"
+        >
+          100
+        </text>
+      </g>
+      <g
+        class="z-axis-tick"
+      >
+        <circle
+          class="z-axis-ring"
+          cx="45"
+          cy="35"
+          r="15"
+          style="fill: none; stroke: #333333; stroke-opacity: 0.8; stroke-width: 1;"
+        />
+        <line
+          class="z-axis-leader"
+          style="stroke: #333333; stroke-opacity: 0.8; stroke-width: 1; stroke-dasharray: 2,2;"
+          x1="45"
+          x2="4"
+          y1="50"
+          y2="50"
+        />
+        <text
+          class="z-axis-label"
+          dominant-baseline="middle"
+          style="fill: #333333; font-family: sans-serif; user-select: none;"
+          text-anchor="end"
+          x="-2"
+          y="50"
+        >
+          50
+        </text>
+      </g>
+      <g
+        class="z-axis-tick"
+      >
+        <circle
+          class="z-axis-ring"
+          cx="45"
+          cy="25"
+          r="5"
+          style="fill: none; stroke: #333333; stroke-opacity: 0.8; stroke-width: 1;"
+        />
+        <line
+          class="z-axis-leader"
+          style="stroke: #333333; stroke-opacity: 0.8; stroke-width: 1; stroke-dasharray: 2,2;"
+          x1="45"
+          x2="4"
+          y1="30"
+          y2="30"
+        />
+        <text
+          class="z-axis-label"
+          dominant-baseline="middle"
+          style="fill: #333333; font-family: sans-serif; user-select: none;"
+          text-anchor="end"
+          x="-2"
+          y="30"
+        >
+          0
+        </text>
+      </g>
+    </g>
+  </svg>
+</DocumentFragment>
+`;

--- a/packages/react/src/lib/components/Axis/ZAxis/index.ts
+++ b/packages/react/src/lib/components/Axis/ZAxis/index.ts
@@ -1,0 +1,1 @@
+export * from "./ZAxis";

--- a/packages/react/src/lib/components/Axis/index.ts
+++ b/packages/react/src/lib/components/Axis/index.ts
@@ -3,3 +3,4 @@ export * from "./XAxis";
 export * from "./YAxis";
 export * from "./AngleAxis";
 export * from "./RadialAxis";
+export * from "./ZAxis";

--- a/packages/react/src/lib/components/Plots/Scatter/Scatter.mdx
+++ b/packages/react/src/lib/components/Plots/Scatter/Scatter.mdx
@@ -22,9 +22,10 @@ The `<Scatter>` component should be used when you want to plot a single scatter 
 | -------------- | --------- | ------------------ | ------------------------------------------------------------------------------------------------------------ |
 | **`x`\***      | `string`  | `null`             | The key of the field that contains the value along the x-axis.                                               |
 | **`y`\***      | `string`  | `null`             | The key of the field that contains the value along the y-axis.                                               |
+| `z`            | `string`  | `null`             | The key of the field used to size each point, relative to the other values of the field. Overrides `radius`. |
 | `color`        | `string`  | Derived from Theme | Override the colour of the series                                                                            |
 | `interactive`  | `boolean` | `true`             | Whether the plot should be interactive. Setting this to false will disable tooltips & markers from this plot |
-| `radius`       | `number`  | `5`                | The radius to use for each data point on the Scatter chart.                                                  |
+| `radius`       | `number`  | `5`                | The radius to use for each data point on the Scatter chart. Ignored if `z` is provided.                       |
 | `showInLegend` | `boolean` | `true`             | Whether the plot should feature in the legend or not.                                                        |
 | `noClip`       | `boolean` | `false`            | Supress clipping of the plot. Useful for showing circles falling on the axis.                                |
 
@@ -33,6 +34,34 @@ The `<Scatter>` component should be used when you want to plot a single scatter 
 Most of the configuration for a `<Scatter>` is similar to other plots. The main styling properties are that of a `radius` property allowing us to adjust the size of the points and a colour option.
 
 <Canvas of={ScatterStories.Radius} />
+
+## Sizing bubbles with `<ZAxis>`
+
+Passing `z` turns `<Scatter>` into a bubble chart, sizing each point by that field's value rather
+than a fixed `radius`. Pair it with a `<ZAxis fields={[z]}>` to draw a legend explaining the size
+encoding - a set of circles nested inside one another, sharing a baseline and each labelled with
+the value it represents, in the style of a New York Times bubble-size legend.
+
+`<ZAxis>` sets up the same underlying scale `<Scatter z>` reads its radius from (like `<XAxis>`/
+`<YAxis>` do for `x`/`y`), so the legend's circles are always drawn at the same size as the series'
+points they describe.
+
+<Canvas of={ScatterStories.BubbleSize} />
+
+### Props
+
+| Prop                 | Type                            | Default    | Note                                                                                          |
+| -------------------- | -------------------------------- | ---------- | ---------------------------------------------------------------------------------------------- |
+| **`fields`\***       | `string \| string[]`              | `null`     | The key of the field used to build the size scale. Only the first field is used.               |
+| `domain`             | `IValue[]`                       | Computed   | Override the domain used by the underlying d3 scale.                                          |
+| `scaleType`          | `IScaleType`                     | Auto       | Override the type of d3 scale to use.                                                         |
+| `range`              | `number[]`                       | `[5, 25]`  | The pixel radius range values are mapped onto. Keep in sync across a shared field.            |
+| `ticks`              | `number`                         | `3`        | The number of representative circles to draw. Ignored when `tickValues` is provided.          |
+| `tickValues`         | `IValue[]`                       | `null`     | Explicit values to draw a circle for, instead of `ticks` picking them automatically.           |
+| `tickFormat`         | `(value) => string`              | `${value}` | Formats each circle's value label.                                                            |
+| `horizontalPosition` | `"LEFT" \| "RIGHT" \| "CENTER"`   | `"RIGHT"`  | Which side of the plot to anchor the legend to.                                                |
+| `verticalPosition`   | `"TOP" \| "BOTTOM"`               | `"BOTTOM"` | Which edge of the plot the circles share a baseline with.                                     |
+| `padding`            | `number`                         | `20`       | The gap, in pixels, between the legend and the edges of the plot area it's anchored to.        |
 
 ## `<Scatters> Component`
 

--- a/packages/react/src/lib/components/Plots/Scatter/Scatter.stories.tsx
+++ b/packages/react/src/lib/components/Plots/Scatter/Scatter.stories.tsx
@@ -7,7 +7,7 @@ import { sales_records_dataset } from "../../../../data/sales_records_dataset";
 import { argTypes } from "../../../../storybook/argTypes";
 import { jitterFields, withDataControls } from "../../../../storybook/dataControls";
 import { createCanvasTest, createSVGTest } from "../../../testUtils";
-import { XAxis, YAxis } from "../../Axis";
+import { XAxis, YAxis, ZAxis } from "../../Axis";
 import { XYChart } from "../../XYChart";
 import { Scatter } from "./Scatter";
 import { Scatters } from "./Scatters";
@@ -188,6 +188,38 @@ export const MultipleScatterCanvas = {
     y2: "Total Revenue",
     y3: "Total Cost",
     useCanvas: true,
+  },
+};
+
+const BubbleSizeTemplate = (args) => (
+  <XYChart
+    data={args.data}
+    plotMargin={{
+      left: args.leftMargin,
+      right: args.rightMargin,
+      top: args.topMargin,
+      bottom: args.bottomMargin,
+    }}
+    width={args.width}
+    height={args.height}
+    animationDuration={args.animationDuration}
+    theme={args.theme}
+    useCanvas={args.useCanvas}
+  >
+    <YAxis fields={[args.y]} />
+    <XAxis fields={[args.x]} />
+    <ZAxis fields={[args.z]} tickFormat={(value) => `$${value}`} />
+    <Scatter x={args.x} y={args.y} z={args.z} color={args.color} noClip />
+  </XYChart>
+);
+
+export const BubbleSize = {
+  name: "Sizing bubbles with ZAxis",
+  render: BubbleSizeTemplate,
+  args: {
+    ...Basic.args,
+    z: "Unit Price",
+    rightMargin: 110,
   },
 };
 


### PR DESCRIPTION
## Summary

- Adds `<ZAxis>`, a legend for the size (`z`) encoding of a `<Scatter z>`/`<Scatters z>` bubble chart: a set of circles nested inside one another sharing a baseline, each labelled via a leader line - in the style of a New York Times bubble-size legend.
- `<ZAxis>` sets up the same `<ZScale>`-backed scale `<Scatter z>`/`<Scatters z>` read their radius from (mirroring how `<XAxis>`/`<YAxis>` set up the `x`/`y` scales), so the legend's circles are always drawn at the same size as the series' points they describe.
- `horizontalPosition`/`verticalPosition` anchor the legend to a corner of the plot; `ticks`/`tickValues`/`tickFormat` control which values get a circle and how they're labelled.
- Adds a `BubbleSize` Scatter story and documents `<ZAxis>`/the `z` prop in `Scatter.mdx`.

## Test plan

- [x] `ZAxis.unit.tsx` - covers the default (bottom-right) legend, a left/top-anchored variant, and explicit `tickValues`
- [x] `pnpm jest` for `Axis`, `Plots/Scatter`, and `Scale` - all pass
- [x] `tsc --noEmit` - clean
- [x] `eslint` on the new/changed files - clean
- [x] Manually rendered the exact SVG output from the unit test snapshot in a browser to confirm the nested-circle/leader-line geometry looks correct

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjQFC7X9SXTrTeP8gR3jLN)_